### PR TITLE
Updated substitutions for new worm source changes

### DIFF
--- a/lib/substitutions.json
+++ b/lib/substitutions.json
@@ -1276,7 +1276,7 @@
       "after": "dislike him?</em>"
     },
     {
-      "before": "answered, annoyed, “ He gets",
+      "before": "answered, annoyed, “He gets",
       "after": "answered, annoyed. “He gets"
     },
     {
@@ -2379,10 +2379,6 @@
     {
       "before": "…Just focus",
       "after": "…just focus"
-    },
-    {
-      "before": "st ill",
-      "after": "still"
     },
     {
       "before": "Rogue friend",


### PR DESCRIPTION
Removed "st ill" change as that seems to have been fixed in source. 

Modified "answered, annoyed, “ He gets" because source has been changed.

Running worm-scraper should have no warnings as of now.