### PR TITLE
Fix failure on convert

### DIFF
--- a/lib/worm-scraper.js
+++ b/lib/worm-scraper.js
@@ -87,7 +87,7 @@ if (argv._.includes("download")) {
 
 if (argv._.includes("convert")) {
   commands.push(() => {
-    return fs.rmdir(chaptersPath, { recursive: true, maxRetries: 3 })
+    return fs.rm(chaptersPath, { force: true, recursive: true, maxRetries: 3 })
       .then(() => fs.mkdir(chaptersPath, { recursive: true }))
       .then(() => convert(cachePath, manifestPath, chaptersPath, argv.book, argv.jobs));
   });


### PR DESCRIPTION
resolves #30 

All credit to node deprecation warnings/Chocbanana who opened #30. Figured I'd just make a PR to make this easier.

I hit this error when creating a ward epub myself and came to the issues to find a solution. This worked for me locally on Windows 10 with node.js 16.10.0.

The bug presents as follows:
```
*downloads*
Downloading https://www.parahumans.net/2020/05/02/last-20-end/... done
(node:19428) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
Error: ENOENT: no such file or directory, stat 'C:\Users\evane\Documents\staging\ward\OEBPS\chapters'
```