### PR TITLE
Added a line to replace a symbol that doesn't appear on Rakuten kobo eReaders

### DIFF
--- a/lib/convert-worker.js
+++ b/lib/convert-worker.js
@@ -262,6 +262,8 @@ function getBodyXML(chapter, book, contentEl) {
     "🤨"
   );
 
+  xml = xml.replace(/<p style="text-align: center;">⊙<\/p>/ug, '<p style="text-align:center;">■</p>');
+
   xml = fixTruncatedWords(xml);
   xml = fixDialogueTags(xml);
   xml = fixForeignNames(xml);


### PR DESCRIPTION
The symbol "⊙" which is used to split sections within chapters in Ward doesn't appear on Kobo readers. 
I added a line to replace it with a "■" which is what is used in Worm. 
