### PR TITLE
Various fixes for Glow-worm

### DIFF
--- a/lib/convert-worker.js
+++ b/lib/convert-worker.js
@@ -31,7 +31,7 @@ function getChapterString(chapter, bookTitle, chapterSubstitutions, rawChapterDo
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en"
       itemscope="itemscope" itemtype="https://schema.org/Chapter"
-      itemid="${chapter.url}" class="chapter">
+      itemid="${chapter.url}" class="chapter ${bookTitle}">
   <head>
     <meta charset="utf-8"/>
     <title>${chapter.usedTitle}</title>
@@ -241,6 +241,7 @@ function getBodyXML(chapter, bookTitle, chapterSubstitutions, contentEl) {
   xml = xml.replace(/<br \/>(\s*)<\/strong>/ug, "</strong><br />$1");
   xml = xml.replace(/(\s*)<\/strong>/ug, "</strong>$1");
   xml = xml.replace(/><strong>(.*)<\/strong>:</ug, "><strong>$1:</strong><");
+  xml = xml.replace(/<strong><br \/>\n/ug, "<br />\n<strong>");
 
   // No need for line breaks before paragraph ends or after paragraph starts
   // These often occur with the <br>s inside <b>/<strong>/<em>/<i> fixed above.
@@ -275,20 +276,25 @@ function getBodyXML(chapter, bookTitle, chapterSubstitutions, contentEl) {
     "🤨"
   );
 
-  xml = fixTruncatedWords(xml);
-  xml = fixDialogueTags(xml);
-  xml = fixForeignNames(xml);
+  // This needs to happen before other name-related fixes.
   xml = standardizeNames(xml);
-  xml = fixEmDashes(xml);
-  xml = enDashJointNames(xml);
-  xml = fixPossessives(xml);
+
+  // Glow-worm is a bunch of people posting online, so they rarely use proper punctuation or standardized spelling, etc.
+  if (bookTitle !== "Glow-worm") {
+    xml = fixTruncatedWords(xml);
+    xml = fixDialogueTags(xml);
+    xml = fixForeignNames(xml);
+    xml = fixEmDashes(xml);
+    xml = enDashJointNames(xml);
+    xml = fixPossessives(xml);
+    xml = fixCapitalization(xml, bookTitle);
+    xml = fixMispellings(xml);
+    xml = fixHyphens(xml);
+    xml = standardizeSpellings(xml);
+    xml = fixCaseNumbers(xml);
+  }
   xml = cleanSceneBreaks(xml);
-  xml = fixCapitalization(xml, bookTitle);
-  xml = fixMispellings(xml);
-  xml = fixHyphens(xml);
-  xml = standardizeSpellings(xml);
-  xml = fixCaseNumbers(xml);
-  xml = fixParahumansOnline(xml, bookTitle);
+  xml = fixParahumansOnline(xml);
 
   // One-off fixes
   for (const substitution of chapterSubstitutions) {
@@ -410,6 +416,12 @@ function standardizeNames(xml) {
 
   // 73 instances of Über to 2 of Uber
   xml = xml.replace(/Uber/ug, "Über");
+
+  // 5 instances of Johnsonjar to 2 instances of JohnsonJar
+  xml = xml.replace(/JohnsonJar/ug, "Johnsonjar");
+
+  // 4 instances of Flying_Kevin to 2 instances of FlyingKevin
+  xml = xml.replace(/FlyingKevin/ug, "Flying_Kevin");
 
   return xml;
 }
@@ -826,7 +838,7 @@ function fixCaseNumbers(xml) {
   return xml;
 }
 
-function fixParahumansOnline(xml, bookTitle) {
+function fixParahumansOnline(xml) {
   xml = xml.replaceAll("Using identity</strong> “<strong>", "Using identity “");
   xml = xml.replaceAll(
     `Forum <span style="text-decoration: underline;">thread.</span>`,
@@ -845,10 +857,6 @@ function fixParahumansOnline(xml, bookTitle) {
     `You are currently logged in, <strong><span style="text-decoration: underline;">$1</span></strong>`
   );
 
-  // /kill should be always lowercase, since it's a bot-command.
-  // The leading space is important to avoid catching "Kiss/Kill".
-  xml = xml.replaceAll(" /Kill", " /kill");
-
   // Most cases have the colon but some don't.
   xml = xml.replace(/(Replied on \w+ \d{1,2}(?:st|nd|rd|th),? ?Y?\d*)<br \/>/ug, "$1:<br />");
 
@@ -858,12 +866,7 @@ function fixParahumansOnline(xml, bookTitle) {
   // It's inconsistent to exclude the punctuation from the bolding; fix it.
   xml = xml.replace(/<strong>Welcome back to (.+?)<\/strong>!/ug, "<strong>Welcome back to $1!</strong>");
 
-  // Glow-worm has some bold paragraphs that look quite bad when justified, so try to force left-alignment.
-  // Don't apply this globally, e.g. to <body>, because there are some long messages, transcribed articles, etc. where
-  // justification is nice.
-  if (bookTitle === "Glow-worm") {
-    xml = xml.replace(/<p><strong>(.*)<\/strong><br \/>/ug, `<p style="text-align: left;"><strong>$1</strong><br />`);
-  }
+  xml = xml.replace(/<p>♦ <strong>(.*)<\/strong><\/p>/ug, `<p><strong>♦ $1</strong></p>`);
 
   return xml;
 }

--- a/scaffolding/OEBPS/chapter.css
+++ b/scaffolding/OEBPS/chapter.css
@@ -23,3 +23,7 @@
 :root.chapter h1 {
   text-align: center;
 }
+
+:root.Glow-worm p {
+  text-align: left;
+}

--- a/substitutions/glow-worm.subs
+++ b/substitutions/glow-worm.subs
@@ -1,4 +1,44 @@
 @ https://www.parahumans.net/2017/10/21/glow-worm-0-1/
-  - <p><em>Ward is the second work in the Parahumans series, and reading</em> <strong><a href="https://parahumans.wordpress.com/">Worm</a></strong> <em>first is strongly recommended.  A lot of this won’t make sense otherwise and if you do find yourself a fan of the universe, the spoilers in Ward will affect the reading of the other work.</em></p>\n<p><em>Ward is not recommended for young or sensitive readers.</em></p>\n<p><em>The Glow-worm chapters were a teaser event leading up to Worm 2.  They aren’t required reading but offer flavor and additional angles by which to view certain characters.  They take the form of forum posts, chat conversations and emails.</em></p>\n<p><em>They’re best described as a kind of a post-epilogue, pseudo-prologue bridge between the series.  Those who read them on the Worm site shouldn’t feel the need to read them again—they’re included here for convenience’s sake, with a few readability improvements.</em></p>\n<p>If you’re not interested or find this hard to read, click <a href="/2017/09/11/daybreak-1-1/"><strong>here</strong></a> to jump to chapter 1.</p>\n<p style="text-align: center;">⊙</p>\n
+  - <p><em>Ward is the second work in the Parahumans series, and reading</em> <strong><a href="https://parahumans.wordpress.com/">Worm</a></strong> <em>first is strongly recommended.  A lot of this won’t make sense otherwise and if you do find yourself a fan of the universe, the spoilers in Ward will affect the reading of the other work.</em></p>\n<p><em>Ward is not recommended for young or sensitive readers.</em></p>\n<p><em>The Glow-worm chapters were a teaser event leading up to Worm 2.  They aren’t required reading but offer flavor and additional angles by which to view certain characters.  They take the form of forum posts, chat conversations and emails.</em></p>\n<p><em>They’re best described as a kind of a post-epilogue, pseudo-prologue bridge between the series.  Those who read them on the Worm site shouldn’t feel the need to read them again – they’re included here for convenience’s sake, with a few readability improvements.</em></p>\n<p>If you’re not interested or find this hard to read, click <a href="/2017/09/11/daybreak-1-1/"><strong>here</strong></a> to jump to chapter 1.</p>\n<p style="text-align: center;">⊙</p>\n
   +
   # This is out of place in an ebook.
+
+  - they’re aloof.<br />\nI say
+  + they’re aloof.</p>\n<p style="padding-left: 30px;">I say
+
+@ https://www.parahumans.net/2017/10/26/glow-worm-0-3/
+  - <strong> Point_Me_@_The_Sky:</strong>
+  + Point_Me_@_The_Sky:
+  # Only the logged-in user is bolded in PHO conversations.
+
+@ https://www.parahumans.net/2017/10/28/glow-worm-0-4/
+  r <br />\n<strong><br />\nof5
+  s </p>\n<p style="padding-left: 30px;"><strong>of5
+
+  - Researching.<br />\nHeart_Shaped_Pupil:
+  + Researching.</p>\n<p style="padding-left: 30px;">Heart_Shaped_Pupil:
+
+  - you’ve talked about 😉 ?<br />\n<strong>of5</strong>:
+  + you’ve talked about 😉 ?</p>\n<p style="padding-left: 30px;"><strong>of5</strong>:
+
+  - technical side, searches.<br />\nHeart_Shaped_Pupil:
+  + technical side, searches.</p>\n<p style="padding-left: 30px;">Heart_Shaped_Pupil:
+
+  - good to our R!<br />\n<strong>of5</strong>:
+  + good to our R!</p>\n<p style="padding-left: 30px;"><strong>of5</strong>:
+
+  - I owe you one.<br />\nQuestionable_Mammal:
+  + I owe you one.</p>\n<p style="padding-left: 30px;">Questionable_Mammal:
+
+  - give on next meet.<br />\n<strong>of5</strong>:
+  + give on next meet.</p>\n<p style="padding-left: 30px;"><strong>of5</strong>:
+
+  - …go keep researching<br />\nHeart_Shaped_Pupil: entertain lady friend!<br />\nQuestionable_Mammal:
+  + go keep researching</p>\n<p style="padding-left: 30px;">Heart_Shaped_Pupil: entertain lady friend!</p>\n<p style="padding-left: 30px;">Questionable_Mammal:
+
+  - a plan of action later.<br />\nHeart_Shaped_Pupil: we’ll figure out a plan of action later &gt;:)<br />\n<strong>of5</strong>:
+  + a plan of action later.</p>\n<p style="padding-left: 30px;">Heart_Shaped_Pupil: we’ll figure out a plan of action later &gt;:)</p>\n<p style="padding-left: 30px;"><strong>of5</strong>:
+
+@ https://www.parahumans.net/2017/10/31/glow-worm-0-6/
+  - <p>A_real: Hello. Thank you for the prompt response. I’m Sydney</p>\n<p>Curious_Cephalopod: I can guess what this is about</p>
+  + <p style="padding-left: 30px;">A_real: Hello. Thank you for the prompt response. I’m Sydney</p>\n<p style="padding-left: 30px;"><strong>Curious_Cephalopod:</strong> I can guess what this is about</p>

--- a/substitutions/ward.subs
+++ b/substitutions/ward.subs
@@ -3602,8 +3602,11 @@
   - listening, lost in tinkering—</p>
   + listening, lost in tinkering—”</p>
 
-  - <p>:Transmit<strong><br />\nI’ve got
-  + <p style="padding-left: 30px;">:Transmit<strong><br />I’ve got
+  - <strong>:</strong>Transmit<br />
+  + :Transmit<br />
+
+  - <p>:Transmit<br />\n<strong>I’ve got
+  + <p style="padding-left: 30px;">:Transmit<br />\n<strong>I’ve got
 
 
 @ https://www.parahumans.net/2020/04/28/last-20-e6/


### PR DESCRIPTION
* Stop justifying all text. We previously tried to un-justify some bold "heading" paragraphs only, but several slipped through, and in general it fits the tone of online conversations better to look more "computer-like" and less "book-like".

* Stop fixing up hyphens, dashes, capitalizations (e.g. "earths" vs. "Earths"), standardized spellings ("ok" vs. "okay"), etc. These fixes do not apply to online conversations.

* Stop un-capitalizing the "/Kill" command. It seems possible that this works capitalized, and most commands typed by Kenzie are capitalized, so this sticks better to author intent. There's also the chance that it's significant, as she has a small line about watching her capitalization and punctuation, and as she gets a bit down, she stops capitalizing the last two commands.

* Fix a couple of inconsistent names: "JohnsonJar" vs. "Johnsonjar" and "FlyingKevin" vs. "Flying_Kevin".

* Fix a few instances of misplaced bolding on usernames (the logged-in user's name is supposed to be bold).

* Fix a few instances of bad paragraph breaks vs. line breaks in chat conversations.

This also includes a bolding spot-fix for Ward Last 20.e5.