### PR TITLE
Various text fixes, mostly to Worm

### DIFF
--- a/lib/convert-worker.js
+++ b/lib/convert-worker.js
@@ -289,8 +289,8 @@ function getBodyXML(chapter, bookTitle, chapterSubstitutions, contentEl) {
     xml = fixPossessives(xml);
     xml = fixCapitalization(xml, bookTitle);
     xml = fixMispellings(xml);
-    xml = fixHyphens(xml);
     xml = standardizeSpellings(xml);
+    xml = fixHyphens(xml);
     xml = fixCaseNumbers(xml);
   }
   xml = cleanSceneBreaks(xml);
@@ -618,11 +618,11 @@ function fixCapitalization(xml, bookTitle) {
   xml = xml.replace(/Fragile one/ug, "Fragile One");
 
   // Place names need to always be capitalized
-  xml = xml.replace(/North end/ug, "North End");
   xml = xml.replace(/(Stonemast|Shale) avenue/ug, "$1 Avenue");
   xml = xml.replace(/(Lord|Slater) street/ug, "$1 Street");
   xml = xml.replace(/(Hollow|Cedar) point/ug, "$1 Point");
   xml = xml.replace(/(Norwalk|Fenway|Stratford) station/ug, "$1 Station");
+  xml = xml.replace(/downtown Brockton Bay/ug, "Downtown Brockton Bay");
   xml = xml.replace(/the megalopolis/ug, "the Megalopolis");
   xml = xml.replace(/earths(?![a-z])/ug, "Earths");
   if (bookTitle === "Ward") {
@@ -707,7 +707,8 @@ function fixHyphens(xml) {
 
   // Compound numbers from 11 through 99 must be hyphenated, but others should not be.
   xml = xml.replace(
-    /(?<!\w)(twenty|thirty|fourty|fifty|sixty|seventy|eighty|ninety) (one|two|three|four|five|six|seven|eight|nine)/uig,
+    // eslint-disable-next-line max-len
+    /(?<!\w)(twenty|thirty|fourty|fifty|sixty|seventy|eighty|ninety) (one|two|three|four|five|six|seven|eight|nine|something)/uig,
     "$1-$2"
   );
   xml = xml.replace(/[- ]hundred-and-/ug, " hundred and ");
@@ -721,7 +722,11 @@ function fixHyphens(xml) {
   xml = xml.replace(/([Ll]ife) threatening/ug, "life-threatening");
   xml = xml.replace(/([Hh]ard) headed/ug, "$1-headed");
   xml = xml.replace(/([Ss]houlder) mounted/ug, "$1-mounted");
-  xml = xml.replace(/([Gg]olden) skinned/ug, "$1-skinned");
+  xml = xml.replace(/([Ss]houlder) length/ug, "$1-length");
+  xml = xml.replace(
+    /([Gg]olden|[Pp]ink|[Bb]rown|[Dd]ark|[Tt]an|[Mm]etal|[Dd]arker|[Yy]ellow|[Oo]live|[Rr]ed|[Gg]ray) skinned/ug,
+    "$1-skinned"
+  );
   xml = xml.replace(/([Cc]reepy) crawl/ug, "$1-crawl");
   xml = xml.replace(/([Ww]ell) armed/ug, "$1-armed");
   xml = xml.replace(/([Aa]ble) bodied/ug, "$1-bodied");
@@ -734,7 +739,12 @@ function fixHyphens(xml) {
   xml = xml.replace(/([Oo]ne) sided/ug, "$1-sided");
   xml = xml.replace(/([Mm]edium) sized/ug, "$1-sized");
   xml = xml.replace(/([Tt]eary) eyed/ug, "$1-eyed");
+  xml = xml.replace(/([Ll]ong|[Ss]hort) sleeved/ug, "$1-sleeved");
+  xml = xml.replace(/([Kk]nee) (length|deep)/ug, "$1-$2");
   xml = xml.replace(/([Ww]orst) case scenario/ug, "$1-case scenario");
+  xml = xml.replace(/([Gg]overnment) sponsored/ug, "$1-sponsored");
+  xml = xml.replace(/([Hh]igh) pitched/ug, "$1-pitched");
+  xml = xml.replace(/([Oo]ne) (eyed|eared)/ug, "$1-$2");
   xml = xml.replace(/([Ss]elf) (conscious|esteem|loathing|harm|destruct|preservation)/ug, "$1-$2");
   xml = xml.replace(/([Oo]ne|[Tt]wo|[Tt]hree|[Ff]our|[Ff]ourth) dimensional/ug, "$1-dimensional");
   xml = xml.replace(/(?<=\b)([Oo]ne) on one(?=\b)/ug, "$1-on-one");

--- a/substitutions/ward.subs
+++ b/substitutions/ward.subs
@@ -104,6 +104,11 @@
   + saying all of that, he would
 
 
+@ https://www.parahumans.net/2018/01/06/glare-3-1/
+  - no longer dominated downtown
+  + no longer dominated Downtown
+
+
 @ https://www.parahumans.net/2018/01/09/glare-3-2/
   - under—and over-growth
   + under- and overgrowth
@@ -1927,6 +1932,9 @@
   - Instead a 1,—2, 4
   + Instead a 1, −2, 4
 
+  - consumed a chunk of downtown
+  + consumed a chunk of Downtown
+
 
 @ https://www.parahumans.net/2019/05/21/breaking-14-2/
   - if Parahumans like Swansong
@@ -2034,6 +2042,9 @@
 
   - I—Only if you hold onto it.
   + I— Only if you hold onto it.
+
+  - claimed more of downtown
+  + claimed more of Downtown
 
 
 @ https://www.parahumans.net/2019/06/22/breaking-14-11/
@@ -2375,6 +2386,9 @@
   + for Kenzie to high-five
   # Here it's a verb
 
+  - south end of downtown and the Towers
+  + south end of Downtown and the Towers
+
 
 @ https://www.parahumans.net/2019/09/07/from-within-16-8/
   - Giant lightning man guard dog
@@ -2694,6 +2708,9 @@
 
   - Asking question?
   + Asking a question?
+
+  - the south end of the towers
+  + the south end of the Towers
 
 
 @ https://www.parahumans.net/2019/11/02/sundown-17-10/
@@ -3542,6 +3559,9 @@
 
   - damocles
   + Damocles
+
+  - the expensive part of downtown
+  + the expensive part of Downtown
 
 
 @ https://www.parahumans.net/2020/04/11/last-20-e1/

--- a/substitutions/worm.subs
+++ b/substitutions/worm.subs
@@ -56,6 +56,12 @@
 
 
 @ https://parahumans.wordpress.com/2011/07/05/insinuation-2-1/
+  - “Christ, Taylor,” my father answered, “This isn’t
+  + “Christ, Taylor,” my father answered, “this isn’t
+
+  - “School,” I said, swallowing around a lump in my throat, “Friends,
+  + “School,” I said, swallowing around a lump in my throat, “friends,
+
   - night,” he said. “Or
   + night,” he said, “or
 
@@ -76,7 +82,18 @@
   + attempt at trying to salvage things
 
 
+@ https://parahumans.wordpress.com/2011/07/19/insinuation-2-5/
+  - downtown was one of the nice areas
+  + Downtown was one of the nice areas
+
+  - half-hour walk to downtown
+  + half-hour walk to Downtown
+
+
 @ https://parahumans.wordpress.com/2011/07/23/insinuation-2-6/
+  - the tops of my shoulders. so that when
+  + the tops of my shoulders, so that when
+
   - costume,—one
   + costume—one
 
@@ -92,21 +109,142 @@
   - line” Lisa told me, “By
   + line,” Lisa told me. “By
 
+  - “Sorry,” Grue… Brian apologized, “That was
+  + “Sorry,” Grue… Brian apologized.  “That was
+
+  - member of the Undersiders,” Brian spoke up, “As one
+  + member of the Undersiders,” Brian spoke up.  “As one
+
+  - “No,” Brian cut in, “That’s just what the
+  + “No,” Brian cut in, “that’s just what the
+
+  - voted yes,” Brian hurried to add, giving Alec a dirty look, “She’ll
+  + voted yes,” Brian hurried to add, giving Alec a dirty look.  “She’ll
+
+  - fucked up Lung,” Lisa shrugged as she spoke, “Good enough
+  + fucked up Lung,” Lisa shrugged as she spoke.  “Good enough
+
+  - “Yeah,” Lisa raised an eyebrow, “You do
+  + “Yeah.” Lisa raised an eyebrow, “You do
+
+  - Black Widow, Brown Recluse, Browntail Moth, Mildei, Fire Ants
+  + black widow, brown recluse, browntail moth, mildei, fire ants
+
+  - “Yeah,” I cut her off, “I don’t know
+  + “Yeah,” I cut her off.  “I don’t know
+
+  - Let’s arrange to check on him in a few hours’.”
+  + Let’s arrange to check on him in a few hours.’”
+
+  - “But he regenerates!” I protested, dropping my hands, “Toxins
+  + “But he regenerates!” I protested, dropping my hands.  “Toxins
+
+  - “Okay, that’s enough,” Brian stopped Lisa before she could go on, “Lung
+  + “Okay, that’s enough,” Brian stopped Lisa before she could go on.  “Lung
+
+  - he doesn’t escape,” Alec said, his voice still quiet but bemused, “Because
+  + he doesn’t escape,” Alec said, his voice still quiet but bemused.  “Because
+
+  - I was at the Library
+  + I was at the library
+
 
 @ https://parahumans.wordpress.com/2011/07/26/insinuation-2-7/
   - explained. “Here’s
   + explained, “here’s
 
+  - I nodded, then exhaled slowly, “It’s not
+  + I nodded, then exhaled slowly.  “It’s not
+
+  - newbie in,” she waved him off, “Yell
+  + newbie in,” she waved him off.  “Yell
+
+  - Taking my silence for awe, she grinned her vulpine smile, “It’s not
+  + Taking my silence for awe, she grinned her vulpine smile.  “It’s not
+
+  - “And,” Brian said, still glowering at Lisa, “Even if
+  + “And,” Brian said, still glowering at Lisa, “even if
+
+
+@ https://parahumans.wordpress.com/2011/07/30/insinuation-2-8/
+  - hate it,” Brian growled at the girl, putting emphasis on the swear, “When
+  + hate it,” Brian growled at the girl, putting emphasis on the swear, “when
+
+  - more fighting,” he said, his voice calmer, “I’m directing
+  + more fighting,” he said, his voice calmer.  “I’m directing
+
+  - “No,” I interrupted him, “Fuck
+  + “No,” I interrupted him.  “Fuck
+
+  - Brian tried again, “Look,
+  + Brian tried again.  “Look,
+
+  - before he could get any further, “You don’t
+  + before he could get any further.  “You don’t
+
+  - opened the door for me, “I’ll
+  + opened the door for me.  “I’ll
+
 
 @ https://parahumans.wordpress.com/2011/08/02/insinuation-2-9/
+  - “Glad you came back,” Lisa told me, a bit of a smile on her face, “Alec
+  + “Glad you came back,” Lisa told me, a bit of a smile on her face.  “Alec
+
+  - you know,” Alec told me, as he returned with the first aid kit, “I didn’t
+  + you know,” Alec told me, as he returned with the first aid kit.  “I didn’t
+
+  - between the boys, “It’s a bit complicated
+  + between the boys.  “It’s a bit complicated
+
+  - any dog, actually,” she said, stressing the name, “And
+  + any dog, actually,” she said, stressing the name.  “And
+
   - Hey dad
   + Hey Dad
 
-  - Really dad
-  + Really Dad
+  - Rose Hebert,” I told him, “Really dad
+  + Rose Hebert,” I told him.  “Really Dad
 
   - The Parahumans wiki
   + The parahumans wiki
+
+
+@ https://parahumans.wordpress.com/2011/08/06/interlude-2/
+  - about it, fugly,” she told him, “You know
+  + about it, fugly,” she told him.  “You know
+
+  - Glory Girl?” Amy asked, in the most sarcastic tone she could manage, “This is
+  + Glory Girl?” Amy asked, in the most sarcastic tone she could manage.  “This is
+
+  - Carol would buy that line,” Amy said, making it clear in her tone she wasn’t, “But
+  + Carol would buy that line,” Amy said, making it clear in her tone she wasn’t.  “But
+
+  - just a team, Ames,” Victoria told her, “We’re
+  + just a team, Ames,” Victoria told her.  “We’re
+
+  - adoptive family,” Amy mumbled into Victoria’s shoulder, “And stop trying
+  + adoptive family,” Amy mumbled into Victoria’s shoulder.  “And stop trying
+
+  - using my power, dumbass,” Victoria told Amy, letting her go, “I’m hugging
+  + using my power, dumbass,” Victoria told Amy, letting her go.  “I’m hugging
+
+  - erectile dysfunction,” Amy said, just loud enough for the thug to hear her, “You fractured
+  + erectile dysfunction,” Amy said, just loud enough for the thug to hear her.  “You fractured
+
+  - ‘Least when
+  + ’Least when
+
+  - “Amy!” Victoria laughed, hugging her sister with one arm, “Weren’t
+  + “Amy!” Victoria laughed, hugging her sister with one arm.  “Weren’t
+
+  - power vacuum in the docks
+  + power vacuum in the Docks
+
+  - ain’t making progress downtown
+  + ain’t making progress Downtown
+
+  - as much money as you’d get downtown
+  + as much money as you’d get Downtown
 
 
 @ https://parahumans.wordpress.com/2011/08/09/agitation-3-1/
@@ -118,6 +256,40 @@
 
   - follow where my my index finger
   + follow where my index finger
+
+  - Brian chuckled a little, “We can afford
+  + Brian chuckled a little.  “We can afford
+
+  - salt-water and seaweed scented
+  + saltwater-and-seaweed-scented
+
+  - abruptly and high-pitched than I would have liked, “God,
+  + abruptly and high-pitched than I would have liked.  “God,
+
+  - to our place,” he told me, “And
+  + to our place,” he told me.  “And
+
+  - bus back to the docks
+  + bus back to the Docks
+
+@ https://parahumans.wordpress.com/2011/08/13/agitation-3-2/
+  - were sparring,” Brian told me, “Lisa’s
+  + were sparring,” Brian told me.  “Lisa’s
+
+  - keep telling you,” Brian said. “You’re
+  + keep telling you,” Brian said, “you’re
+
+  - bring my taser,” was Alec’s response, “one
+  + bring my taser,” was Alec’s response.  “One
+
+  - The balls of your feet.  He raised his bare
+  + The balls of your feet.”  He raised his bare
+
+  - where the ankle met the ground, “this is the
+  + where the ankle met the ground.  “This is the
+
+  - behind me startled me, “This.
+  + behind me startled me.  “This.
 
 
 @ https://parahumans.wordpress.com/2011/08/16/agitation-3-3/
@@ -160,6 +332,9 @@
   - Lisa continued. “Is
   + Lisa continued, “is
 
+  - the midst of downtown
+  + the midst of Downtown
+
 
 @ https://parahumans.wordpress.com/2011/09/03/agitation-3-8/
   - direction</p>
@@ -199,6 +374,9 @@
 
   - Tattletale winced. “Pop
   + Tattletale winced, “pop
+
+  - leisurely through downtown
+  + leisurely through Downtown
 
 
 @ https://parahumans.wordpress.com/2011/09/20/interlude-3-2/
@@ -310,6 +488,11 @@
 
   - Brian looked across the room,” We’ve
   + Brian looked across the room.  “We’ve
+
+
+@ https://parahumans.wordpress.com/2011/11/05/hive-5-1/
+  - half of downtown
+  + half of Downtown
 
 
 @ https://parahumans.wordpress.com/2011/11/12/hive-5-3/
@@ -434,6 +617,12 @@
   - news:  A tally
   + news: a tally
 
+  - southeast end of downtown
+  + southeast end of Downtown
+
+  - other buildings of downtown
+  + other buildings of Downtown
+
 
 @ https://parahumans.wordpress.com/2011/12/20/tangle-6-3/
   - black leather  Not that
@@ -473,12 +662,20 @@
   + Somehow,” Grue retorted, “I’m
 
 
+@ https://parahumans.wordpress.com/2012/01/03/tangle-6-7/
+  - people in the downtown area
+  + people in the Downtown area
+
+
 @ https://parahumans.wordpress.com/2012/01/07/tangle-6-8/
   - West
   + west
 
   - to the North
   + to the north
+
+  - the North end
+  + the North End
 
 
 @ https://parahumans.wordpress.com/2012/01/10/tangle-6-9/
@@ -883,6 +1080,18 @@
   - broken up by the the wall above the door
   + broken up by the wall above the door
 
+  - south, towards downtown
+  + south, towards Downtown
+
+  - One closer to downtown
+  + One closer to Downtown
+
+  - through the city and downtown
+  + through the city and Downtown
+
+  - sinkhole in downtown
+  + sinkhole in Downtown
+
 
 @ https://parahumans.wordpress.com/2012/03/20/extermination-8-6/
   - and It—it’s
@@ -955,6 +1164,9 @@
   - of her head, “And my
   + of her head. “And my
 
+  - permanent part of downtown
+  + permanent part of Downtown
+
   - KOOROW   BULLIT<br />\nMILK              STUMPY<br />\nBROOTUS  JOODUS<br />\nAXIL     GINGIR
   + KOOROW   BULLIT<br />\nMILK              STUMPY<br />\nBROOTUS  JOODUS<br />\nAXIL     GINGIR
   # This section plays poorly with our space-normalizing heuristic.
@@ -981,6 +1193,9 @@
 
   - Mr. Pitter, “The Travelers’
   + Mr. Pitter. “The Travelers’
+
+  - in the middle of downtown
+  + in the middle of Downtown
 
 
 @ https://parahumans.wordpress.com/2012/04/03/cell-9-1/
@@ -1075,6 +1290,9 @@
 
   - real hair</p>
   + real hair.</p>
+
+  - the downtown area
+  + the Downtown area
 
 
 @ https://parahumans.wordpress.com/2012/04/10/sentinel-9-3/
@@ -1291,6 +1509,9 @@
   - intimidated, “Will work
   + intimidated, “will work
 
+  - border to the downtown area
+  + border to the Downtown area
+
 
 @ https://parahumans.wordpress.com/2012/05/15/interlude-10/
   - host: Annoyance
@@ -1307,6 +1528,9 @@
 
   - So what did he do do you?
   + So what did he do to you?
+
+  - to a place downtown
+  + to a place Downtown
 
 
 @ https://parahumans.wordpress.com/2012/05/17/interlude-10-5-bonus/
@@ -1589,6 +1813,18 @@
   - pointed out, “If we agreed
   + pointed out. “If we agreed
 
+  - upper downtown area
+  + upper Downtown area
+
+  - upper downtown neighborhoods
+  + upper Downtown neighborhoods
+
+  - at the downtown coast
+  + at the Downtown coast
+
+  - heart of downtown, the towers
+  + heart of Downtown, the Towers
+
 
 @ https://parahumans.wordpress.com/2012/07/03/plague-12-3/
   - Noelle, “ Trickster said, “You’ve asked
@@ -1649,6 +1885,9 @@
   - leaving the space that mom had once occupied
   + leaving the space that Mom had once occupied
 
+  - upper downtown area
+  + upper Downtown area
+
 
 @ https://parahumans.wordpress.com/2012/07/14/plague-12-6/
   - had their shots” I said
@@ -1666,6 +1905,9 @@
 
   - cure-all nor
   + cure-all, nor
+
+  - people from the docks
+  + people from the Docks
 
 
 @ https://parahumans.wordpress.com/2012/07/26/interlude-12%C2%BD/
@@ -1698,6 +1940,14 @@
   - And,” Lisa said. “She
   + And,” Lisa said, “she
 
+  - the downtown areas
+  + the Downtown areas
+
+
+@ https://parahumans.wordpress.com/2012/07/31/snare-13-2/
+  - nice part of downtown
+  + nice part of Downtown
+
 
 @ https://parahumans.wordpress.com/2012/08/02/interlude-13%C2%BD-donation-bonus/
   - hon,” Celia said. “We’ve
@@ -1727,6 +1977,9 @@
 @ https://parahumans.wordpress.com/2012/08/21/snare-13-8/
   - occupied: A
   + occupied: a
+
+  - far as she can get from downtown
+  + far as she can get from Downtown
 
 
 @ https://parahumans.wordpress.com/2012/08/25/snare-13-09/
@@ -1765,6 +2018,9 @@
   - through.We crossed
   + through.  We crossed
 
+  r central downtown
+  s central Downtown
+
 
 @ https://parahumans.wordpress.com/2012/09/15/prey-14-4/
   - a ‘<em>No, you just told me.</em>’, but
@@ -1789,15 +2045,33 @@
   - through the suit</em>?
   + through the suit?</em>
 
+  - heading up toward the docks
+  + heading up toward the Docks
+
+  - two bad incidents downtown
+  + two bad incidents Downtown
+
 
 @ https://parahumans.wordpress.com/2012/10/09/prey-14-11/
   - belt: He
   + belt: he
 
+  - the downtown area
+  + the Downtown area
+
+  - from downtown to the Boat Graveyard
+  + from Downtown to the Boat Graveyard
+
 
 @ https://parahumans.wordpress.com/2012/10/11/interlude-14/
   - hard about it
   + heard about it
+
+  - the downtown area
+  + the Downtown area
+
+  - <em>All</em> of downtown
+  + <em>All</em> of Downtown
 
 
 @ https://parahumans.wordpress.com/2012/10/13/interlude-14-5-bonus-interlude/
@@ -1913,6 +2187,9 @@
   - better pictures of mom
   + better pictures of Mom
 
+  - At the North end?
+  + At the North End?
+
 
 @ https://parahumans.wordpress.com/2012/11/20/interlude-15/
   - before,” Dragon replied. “Is
@@ -1920,6 +2197,9 @@
 
   - Once dad and the sibs realized
   + Once Dad and the sibs realized
+
+  - bombs on central downtown
+  + bombs on central Downtown
 
 
 @ https://parahumans.wordpress.com/2012/11/24/monarch-16-1/
@@ -1936,6 +2216,11 @@
 @ https://parahumans.wordpress.com/2012/11/27/monarch-16-2/
   - that,” Grue said. “Is
   + that,” Grue said, “is
+
+
+@ https://parahumans.wordpress.com/2012/11/29/interlude-16-donation-bonus/
+  - centerpiece of the ‘downtown’ area
+  + centerpiece of the ‘Downtown’ area
 
 
 @ https://parahumans.wordpress.com/2012/12/01/monarch-16-3/
@@ -1980,6 +2265,9 @@
   + their positioning… They had planned this
   # A comma seems like the wrong choice here.
 
+  - when the docks were bustling
+  + when the Docks were bustling
+
 
 @ https://parahumans.wordpress.com/2012/12/22/monarch-16-9/
   - aisles</p>
@@ -1998,6 +2286,12 @@
 
   - alright,” I said. “We’ll
   + alright,” I said, “we’ll
+
+  - flourishing North end
+  + flourishing North End
+
+  - restoration project for the North end
+  + restoration project for the North End
 
 
 @ https://parahumans.wordpress.com/2012/12/29/monarch-16-11/
@@ -2020,6 +2314,9 @@
 
   - as much or more about Parahumans than
   + as much or more about parahumans than
+
+  - the dim noise of downtown again
+  + the dim noise of Downtown again
 
 
 @ https://parahumans.wordpress.com/2013/01/08/migration-17-1/
@@ -2279,6 +2576,9 @@
   - earth-shaking
   + earthshaking
 
+  - saltwater scented
+  + saltwater-scented
+
 
 @ https://parahumans.wordpress.com/2013/02/12/queen-18-8/
   - dragged long
@@ -2391,6 +2691,9 @@
   - possible,” Tattletale said. “We’d
   + possible,” Tattletale said, “we’d
 
+  - my way to the North end
+  + my way to the North End
+
 
 @ https://parahumans.wordpress.com/2013/03/16/interlude-19-y/
   - Brockton bay
@@ -2400,8 +2703,11 @@
   + south
 
   - Unfortunate tinker
-  + Unfortunate tinker
+  + Unfortunate Tinker
   # See convert-worker.js; this corrects an over-correction
+
+  - North end, lives in the area
+  + North End, lives in the area
 
 
 @ https://parahumans.wordpress.com/2013/03/19/interlude-19/
@@ -2426,6 +2732,9 @@
 
   - of anxiety</em>.
   + of anxiety.</em>
+
+  - portal in the downtown area
+  + portal in the Downtown area
 
 
 @ https://parahumans.wordpress.com/2013/03/26/chrysalis-20-3/
@@ -2544,6 +2853,9 @@
 
   - <em>sorry that</em>
   + <em>sorry</em> that
+
+  - upper end of downtown
+  + upper end of Downtown
 
 
 @ https://parahumans.wordpress.com/2013/04/25/imago-21-7/
@@ -2813,6 +3125,9 @@
 
   - between each attack.<br />\nThese coming days and weeks
   + between each attack.</p>\n<p>These coming days and weeks
+
+  - the downtown area
+  + the Downtown area
 
 
 @ https://parahumans.wordpress.com/2013/07/06/scarab-25-3/
@@ -3268,17 +3583,16 @@
 
 
 @ https://parahumans.wordpress.com/2013/10/19/speck-30-3/
+  # There are several "typos" in this chapter that are intentional, due to perceptual issues from our viewpoint character: at least "undecision" instead of "indecision", and "alleged" instead of "allied".
+
   - She’s—You’re looking in
   + She’s— You’re looking in
-
-  - anyone alleged with
-  + anyone allied with
 
   - coordinating two teams</em>.
   + coordinating two teams.</em>
 
-  - undecision
-  + indecision
+  - Brockton Bay again, downtown this time
+  + Brockton Bay again, Downtown this time
 
 
 @ https://parahumans.wordpress.com/2013/10/22/speck-30-4/


### PR DESCRIPTION
* Spot fixes ported from my latest Worm read-through up until 3.2. Mostly dialogue tag issues.

* Random spot fixes to Worm 18.7 and 19.y.

* Undid some fixes to Worm 30.3, as the mistakes there are actually aligned with author intent.

* Standardize on capitalizing district and other place names, when used as such: Downtown, the Towers, the Boardwalk, the North End, the Docks, etc.

* Hyphenate one-eyed, one-eared, knee-length, knee-deep, long-sleeved, short-sleeved, twenty-something, shoulder-length, high-pitched, government-sponsored, and (various)-skinned.