### PR TITLE
Another large batch of content fixes

### DIFF
--- a/lib/convert-worker.js
+++ b/lib/convert-worker.js
@@ -155,124 +155,123 @@ function getBodyXML(chapter, bookTitle, chapterSubstitutions, contentEl) {
   let xml = xmlSerializer.serializeToString(bodyEl);
 
   // Fix recurring strange pattern of extra <br> in <p>...<em>...<br>\n</em></p>
-  xml = xml.replace(/<br \/>\s*<\/em><\/p>/ug, "</em></p>");
+  xml = xml.replace(/<br \/>\s*<\/em><\/p>/vg, "</em></p>");
 
   // Replace single-word <i>s with <em>s. Other <i>s are probably erroneous too, but these are known-bad.
-  xml = xml.replace(/<i>([^ ]+)<\/i>/ug, "<em>$1</em>");
-  xml = xml.replace(/<i>([^ ]+)( +)<\/i>/ug, "<em>$1</em>$2");
+  xml = xml.replace(/<i>([^ ]+)<\/i>/vg, "<em>$1</em>");
+  xml = xml.replace(/<i>([^ ]+)( +)<\/i>/vg, "<em>$1</em>$2");
 
   // There are way too many nonbreaking spaces where they don't belong. If they show up three in a row, then let them
   // live; they're maybe being used for alignment or something. Otherwise, they die.
   //
   // Also, normalize spaces after a period/quote mark to two (normal) spaces. The second one is invisible when
   // rendered, but it helps future heuristics detect end of sentences.
-  xml = xml.replace(/\xA0{1,2}(?!\x20\xA0)/ug, " ");
-  xml = xml.replace(/([.”])\x20*\xA0[\xA0\x20]*/ug, "$1  ");
-  xml = xml.replace(/([.”])\x20{3,}/ug, "$1  ");
+  xml = xml.replace(/\xA0{1,2}(?!\x20\xA0)/vg, " ");
+  xml = xml.replace(/([.”])\x20*\xA0[\xA0\x20]*/vg, "$1  ");
+  xml = xml.replace(/([.”])\x20{3,}/vg, "$1  ");
 
   function fixEms() {
     // Fix recurring broken-up or erroneous <em>s
-    xml = xml.replace(/<\/em>‘s/ug, "’s</em>");
-    xml = xml.replace(/<em><\/em>/ug, "");
-    xml = xml.replace(/<\/em><em>/ug, "");
-    xml = xml.replace(/<em>(\s?\s?[^A-Za-z]\s?\s?)<\/em>/ug, "$1");
-    xml = xml.replace(/<\/em>(\s?\s?[^A-Za-z]\s?\s?)<em>/ug, "$1");
-    xml = xml.replace(/“<em>([^>]+)<\/em>(!|\?|\.)”/ug, "“<em>$1$2</em>”");
-    xml = xml.replace(/<p><em>([^>]+)<\/em>(!|\?|\.)<\/p>/ug, "<p><em>$1$2</em></p>");
-    xml = xml.replace(/(!|\?|\.)\s{2}<\/em><\/p>/ug, "$1</em></p>");
-    xml = xml.replace(/<em>([a-z]+)(\?|\.)<\/em>/ug, "<em>$1</em>$2");
-    xml = xml.replace(/<em>([^>]+?)( +)<\/em>/ug, "<em>$1</em>$2");
-    xml = xml.replace(/<em> ([a-zA-Z]+)<\/em>/ug, " <em>$1</em>");
-    xml = xml.replace(/<em>‘\s*([^<]+)\s*’<\/em>/ug, "‘<em>$1</em>’");
-    xml = xml.replace(/<em>‘\s*([^<]+)\s*<\/em>\s*’/ug, "‘<em>$1</em>’");
-    xml = xml.replace(/‘\s*<em>\s*([^<]+)\s*’<\/em>/ug, "‘<em>$1</em>’");
-    xml = xml.replace(/<em>“\s*([^<”]+)\s*”<\/em>/ug, "“<em>$1</em>”");
-    xml = xml.replace(/<em>“\s*([^<”]+)\s*<\/em>\s*”/ug, "“<em>$1</em>”");
-    xml = xml.replace(/“\s*<em>\s*([^<”]+)\s*”<\/em>/ug, "“<em>$1</em>”");
-    xml = xml.replace(/([^\n>])<em>  ?/ug, "$1 <em>");
-    xml = xml.replace(/  ?<\/em>/ug, "</em> ");
-    xml = xml.replace(/<p([^>]+)> <em>/ug, "<p$1><em>");
-    xml = xml.replace(/<\/em> <\/p>/ug, "</em></p>");
-    xml = xml.replace(/<em>([a-z]+),<\/em>/ug, "<em>$1</em>,");
+    xml = xml.replace(/<\/em>‘s/vg, "’s</em>");
+    xml = xml.replace(/<em><\/em>/vg, "");
+    xml = xml.replace(/<\/em><em>/vg, "");
+    xml = xml.replace(/<em>(\s?\s?[^A-Za-z]\s?\s?)<\/em>/vg, "$1");
+    xml = xml.replace(/<\/em>(\s?\s?[^A-Za-z]\s?\s?)<em>/vg, "$1");
+    xml = xml.replace(/“<em>([^>]+)<\/em>(!|\?|\.)”/vg, "“<em>$1$2</em>”");
+    xml = xml.replace(/<p><em>([^>]+)<\/em>(!|\?|\.)<\/p>/vg, "<p><em>$1$2</em></p>");
+    xml = xml.replace(/(!|\?|\.)\s{2}<\/em><\/p>/vg, "$1</em></p>");
+    xml = xml.replace(/<em>([a-z]+)(\?|\.)<\/em>/vg, "<em>$1</em>$2");
+    xml = xml.replace(/<em>([^>]+?)( +)<\/em>/vg, "<em>$1</em>$2");
+    xml = xml.replace(/<em> ([a-zA-Z]+)<\/em>/vg, " <em>$1</em>");
+    xml = xml.replace(/<em>‘\s*([^<]+)\s*’<\/em>/vg, "‘<em>$1</em>’");
+    xml = xml.replace(/<em>‘\s*([^<]+)\s*<\/em>\s*’/vg, "‘<em>$1</em>’");
+    xml = xml.replace(/‘\s*<em>\s*([^<]+)\s*’<\/em>/vg, "‘<em>$1</em>’");
+    xml = xml.replace(/<em>“\s*([^<”]+)\s*”<\/em>/vg, "“<em>$1</em>”");
+    xml = xml.replace(/<em>“\s*([^<”]+)\s*<\/em>\s*”/vg, "“<em>$1</em>”");
+    xml = xml.replace(/“\s*<em>\s*([^<”]+)\s*”<\/em>/vg, "“<em>$1</em>”");
+    xml = xml.replace(/([^\n>])<em>  ?/vg, "$1 <em>");
+    xml = xml.replace(/  ?<\/em>/vg, "</em> ");
+    xml = xml.replace(/<p([^>]+)> <em>/vg, "<p$1><em>");
+    xml = xml.replace(/<\/em> <\/p>/vg, "</em></p>");
+    xml = xml.replace(/<em>([a-z]+),<\/em>/vg, "<em>$1</em>,");
   }
 
   // These quote/apostrophe/em fixes interact with each other. TODO: try to disentangle so we don't repeat all of
   // fixEms.
-  xml = xml.replace(/,” <\/em>/ug, "</em>,” ");
+  xml = xml.replace(/,” <\/em>/vg, "</em>,” ");
   fixEms();
-  xml = xml.replace(/<p>”/ug, "<p>“");
-  xml = xml.replace(/“\s*<\/p>/ug, "”</p>");
-  xml = xml.replace(/“\s*<\/em><\/p>/ug, "</em>”</p>");
-  xml = xml.replace(/‘\s*<\/p>/ug, "’</p>");
-  xml = xml.replace(/‘\s*<\/em><\/p>/ug, "’</em></p>");
-  xml = xml.replace(/,” <\/em>/ug, "</em>,” ");
-  xml = xml.replace(/′/ug, "’");
-  xml = xml.replace(/″/ug, "”");
-  xml = xml.replace(/([A-Za-z])‘s(\s?)/ug, "$1’s$2");
-  xml = xml.replace(/I‘m/ug, "I’m");
-  xml = xml.replace(/<p>“\s+/ug, "<p>“");
-  xml = xml.replace(/\s+”/ug, "”");
-  xml = xml.replace(/'/ug, "’");
-  xml = xml.replace(/’([A-Za-z]+)’/ug, "‘$1’");
-  xml = xml.replace(/([a-z])”<\/p>/ug, "$1.”</p>");
+  xml = xml.replace(/<p>”/vg, "<p>“");
+  xml = xml.replace(/“\s*<\/p>/vg, "”</p>");
+  xml = xml.replace(/“\s*<\/em><\/p>/vg, "</em>”</p>");
+  xml = xml.replace(/‘\s*<\/p>/vg, "’</p>");
+  xml = xml.replace(/‘\s*<\/em><\/p>/vg, "’</em></p>");
+  xml = xml.replace(/,” <\/em>/vg, "</em>,” ");
+  xml = xml.replace(/′/vg, "’");
+  xml = xml.replace(/″/vg, "”");
+  xml = xml.replace(/([A-Za-z])‘s(\s?)/vg, "$1’s$2");
+  xml = xml.replace(/I‘m/vg, "I’m");
+  xml = xml.replace(/<p>“\s+/vg, "<p>“");
+  xml = xml.replace(/\s+”/vg, "”");
+  xml = xml.replace(/'/vg, "’");
+  xml = xml.replace(/’([A-Za-z]+)’/vg, "‘$1’");
+  xml = xml.replace(/([a-z])”<\/p>/vg, "$1.”</p>");
   fixEms();
-  xml = xml.replace(/‘<em>([^<]+)<\/em>‘/ug, "‘<em>$1</em>’");
-  xml = xml.replace(/<em>([a-z]+)!<\/em>/ug, "<em>$1</em>!");
-  xml = xml.replace(/(?<! {2})<em>([\w ’]+)([!.?])”<\/em>/ug, "<em>$1</em>$2”");
-  xml = xml.replace(/<em>([\w ’]+[!.?])”<\/em>/ug, "<em>$1</em>”");
-  xml = xml.replace(/I”(m|ll)/ug, "I’$1");
-  xml = xml.replace(/””<\/p>/ug, "”</p>");
-  xml = xml.replace(/^([^“]+?) ?”(?![ —<])/ugm, "$1 “");
-  xml = xml.replace(/(?<!“)<em>([A-Za-z]+),<\/em>(?!”| +[A-Za-z]+ thought)/u, "<em>$1</em>,");
-  xml = xml.replace(/‘([Kk])ay(?!’)/ug, "’$1ay");
-  xml = xml.replace(/<em>(Why|What|Who|How|Where|When)<\/em>\?/ug, "<em>$1?</em>");
-  xml = xml.replace(/,<\/em>/ug, "</em>,");
-  xml = xml.replace(/,”<\/p>/ug, ".”</p>");
-  xml = xml.replace(/<p>(.*),<\/p>/ug, "<p>$1.</p>");
-  xml = xml.replace(/‘(\w+)‘(\w+)’/ug, "‘$1’$2’");
-  xml = xml.replace(/<em>([a-z]+), ([a-z]+)<\/em>/ug, "<em>$1</em>, <em>$2</em>");
+  xml = xml.replace(/‘<em>([^<]+)<\/em>‘/vg, "‘<em>$1</em>’");
+  xml = xml.replace(/<em>([a-z]+)!<\/em>/vg, "<em>$1</em>!");
+  xml = xml.replace(/(?<! {2})<em>([\w ’]+)([!.?])”<\/em>/vg, "<em>$1</em>$2”");
+  xml = xml.replace(/<em>([\w ’]+[!.?])”<\/em>/vg, "<em>$1</em>”");
+  xml = xml.replace(/I”(m|ll)/vg, "I’$1");
+  xml = xml.replace(/””<\/p>/vg, "”</p>");
+  xml = xml.replace(/^([^“]+?) ?”(?![ —<])/vgm, "$1 “");
+  xml = xml.replace(/(?<!“)<em>([A-Za-z]+),<\/em>(?!”| +[A-Za-z]+ thought)/vg, "<em>$1</em>,");
+  xml = xml.replace(/‘([Kk])ay(?!’)/vg, "’$1ay");
+  xml = xml.replace(/<em>(Why|What|Who|How|Where|When)<\/em>\?/vg, "<em>$1?</em>");
+  xml = xml.replace(/,<\/em>/vg, "</em>,");
+  xml = xml.replace(/,”<\/p>/vg, ".”</p>");
+  xml = xml.replace(/<p>(.*),<\/p>/vg, "<p>$1.</p>");
+  xml = xml.replace(/‘(\w+)‘(\w+)’/vg, "‘$1’$2’");
+  xml = xml.replace(/<em>([a-z]+), ([a-z]+)<\/em>/vg, "<em>$1</em>, <em>$2</em>");
 
   // Similar problems occur in Ward with <b> and <strong> as do in Worm with <em>s
-  xml = xml.replace(/<b \/>/ug, "");
-  xml = xml.replace(/<b>(\s*<br \/>\s*)<\/b>/ug, "$1");
-  xml = xml.replace(/<strong>(\s*<br \/>\s*)<\/strong>/ug, "$1");
-  xml = xml.replace(/<\/strong>(\s*)<strong>/ug, "$1");
-  xml = xml.replace(/<strong>@<\/strong>/ug, "@");
-  xml = xml.replace(/<br \/>(\s*)<\/strong>/ug, "</strong><br />$1");
-  xml = xml.replace(/(\s*)<\/strong>/ug, "</strong>$1");
-  xml = xml.replace(/><strong>(.*)<\/strong>:</ug, "><strong>$1:</strong><");
-  xml = xml.replace(/<strong><br \/>\n/ug, "<br />\n<strong>");
+  xml = xml.replace(/<b \/>/vg, "");
+  xml = xml.replace(/<b>(\s*<br \/>\s*)<\/b>/vg, "$1");
+  xml = xml.replace(/<strong>(\s*<br \/>\s*)<\/strong>/vg, "$1");
+  xml = xml.replace(/<\/strong>(\s*)<strong>/vg, "$1");
+  xml = xml.replace(/<strong>@<\/strong>/vg, "@");
+  xml = xml.replace(/<br \/>(\s*)<\/strong>/vg, "</strong><br />$1");
+  xml = xml.replace(/(\s*)<\/strong>/vg, "</strong>$1");
+  xml = xml.replace(/><strong>(.*)<\/strong>:</vg, "><strong>$1:</strong><");
+  xml = xml.replace(/<strong><br \/>\n/vg, "<br />\n<strong>");
 
   // No need for line breaks before paragraph ends or after paragraph starts
   // These often occur with the <br>s inside <b>/<strong>/<em>/<i> fixed above.
-  xml = xml.replace(/<br \/>\s*<\/p>/ug, "</p>");
-  xml = xml.replace(/<p><br \/>\s*/ug, "<p>");
+  xml = xml.replace(/<br \/>\s*<\/p>/vg, "</p>");
+  xml = xml.replace(/<p><br \/>\s*/vg, "<p>");
 
   // This is another quote fix but it needs to happen after the line break deletion... so entangled, ugh.
-  xml = xml.replace(/<\/em>\s*“\s*<\/p>/ug, "</em>”</p>");
+  xml = xml.replace(/<\/em>\s*“\s*<\/p>/vg, "</em>”</p>");
 
   // Fix missing spaces after commas
-  xml = xml.replace(/([a-zA-Z]+),([a-zA-Z]+)/ug, "$1, $2");
+  xml = xml.replace(/([a-zA-Z]+),([a-zA-Z]+)/vg, "$1, $2");
 
   // Fix bad periods and spacing/markup surrounding them
-  xml = xml.replace(/\.\.<\/p>/ug, ".</p>");
-  xml = xml.replace(/\.\.”<\/p>/ug, ".”</p>");
-  xml = xml.replace(/ \. /ug, ". ");
-  xml = xml.replace(/ \.<\/p>/ug, ".</p>");
-  xml = xml.replace(/\.<em>\.\./ug, "<em>…");
-  xml = xml.replace(/\.\. {2}/ug, ".  ");
-  xml = xml.replace(/\.\./ug, "…");
-  xml = xml.replace(/(?<!Mr|Ms|Mrs)…\./ug, "…");
-  xml = xml.replace(/(?<=Mr|Ms|Mrs)…\./ug, ".…");
+  xml = xml.replace(/\.\.<\/p>/vg, ".</p>");
+  xml = xml.replace(/\.\.”<\/p>/vg, ".”</p>");
+  xml = xml.replace(/ \. /vg, ". ");
+  xml = xml.replace(/ \.<\/p>/vg, ".</p>");
+  xml = xml.replace(/\.<em>\.\./vg, "<em>…");
+  xml = xml.replace(/\.\. {2}/vg, ".  ");
+  xml = xml.replace(/\.\./vg, "…");
+  xml = xml.replace(/(?<!Mr|Ms|Mrs)…\./vg, "…");
+  xml = xml.replace(/(?<=Mr|Ms|Mrs)…\./vg, ".…");
 
   // Fix extra spaces
-  xml = xml.replace(/ ? <\/p>/ug, "</p>");
-  xml = xml.replace(/([a-z]) ,/ug, "$1,");
+  xml = xml.replace(/ ? <\/p>/vg, "</p>");
+  xml = xml.replace(/([a-z]) ,/vg, "$1,");
 
   // Use actual emojis instead of images
-  xml = xml.replace(
-    // eslint-disable-next-line max-len
-    /<img width="16" height="16" class="wp-smiley emoji" draggable="false" alt="O_o" src="https:\/\/s1.wp.com\/wp-content\/mu-plugins\/wpcom-smileys\/o_O.svg" style="height: 1em; max-height: 1em;" \/>/ug,
+  xml = xml.replaceAll(
+    `<img width="16" height="16" class="wp-smiley emoji" draggable="false" alt="O_o" src="https://s1.wp.com/wp-content/mu-plugins/wpcom-smileys/o_O.svg" style="height: 1em; max-height: 1em;" />`,
     "🤨"
   );
 
@@ -318,8 +317,8 @@ function getBodyXML(chapter, bookTitle, chapterSubstitutions, contentEl) {
   }
 
   // Serializer inserts extra xmlns for us since it doesn't know we're going to put this into a <html>.
-  xml = xml.replace(
-    /<body xmlns="http:\/\/www.w3.org\/1999\/xhtml">/u,
+  xml = xml.replaceAll(
+    `<body xmlns="http://www.w3.org/1999/xhtml">`,
     `<body>\n`
   );
 
@@ -327,23 +326,23 @@ function getBodyXML(chapter, bookTitle, chapterSubstitutions, contentEl) {
 }
 
 function fixTruncatedWords(xml) {
-  xml = xml.replace(/‘Sup/ug, "’Sup");
-  xml = xml.replace(/‘cuz/ug, "’cuz");
+  xml = xml.replace(/‘Sup/vg, "’Sup");
+  xml = xml.replace(/‘cuz/vg, "’cuz");
 
   // Short for "Sidepeace"
-  xml = xml.replace(/[‘’][Pp]iece(?![a-z])/ug, "’Piece");
+  xml = xml.replace(/[‘’][Pp]iece(?![a-z])/vg, "’Piece");
 
   // Short for "Disjoint"
-  xml = xml.replace(/[‘’][Jj]oint(?![a-z])/ug, "’Joint");
+  xml = xml.replace(/[‘’][Jj]oint(?![a-z])/vg, "’Joint");
 
   // Short for "Contender"
-  xml = xml.replace(/[‘’][Tt]end(?![a-z])/ug, "’Tend");
+  xml = xml.replace(/[‘’][Tt]end(?![a-z])/vg, "’Tend");
 
   // Short for "Anelace"
-  xml = xml.replace(/[‘’][Ll]ace(?![a-z])/ug, "’Lace");
+  xml = xml.replace(/[‘’][Ll]ace(?![a-z])/vg, "’Lace");
 
   // Short for "Birdcage"
-  xml = xml.replace(/[‘’][Cc]age(?![a-z])/ug, "’Cage");
+  xml = xml.replace(/[‘’][Cc]age(?![a-z])/vg, "’Cage");
 
   // We can't do "’Clear" (short for Crystalclear) here because it appears too much as a normal word preceded by an
   // open quote, so we do that in the substitutions file.
@@ -353,8 +352,8 @@ function fixTruncatedWords(xml) {
 
 function fixDialogueTags(xml) {
   // Fix recurring miscapitalization with questions
-  xml = xml.replace(/\?”\s\s?She asked/ug, "?” she asked");
-  xml = xml.replace(/\?”\s\s?He asked/ug, "?” he asked");
+  xml = xml.replace(/\?”\s\s?She asked/vg, "?” she asked");
+  xml = xml.replace(/\?”\s\s?He asked/vg, "?” he asked");
 
   // The author often fails to terminate a sentence, instead using a comma after a dialogue tag. For example,
   // > “I didn’t get much done,” Greg said, “I got distracted by...
@@ -370,114 +369,114 @@ function fixDialogueTags(xml) {
   // This applies to ~800 instances, so although we have to correct back in the substitutions file a decent number of
   // times, it definitely pays for itself. Most of the instances we have to correct back we also need to fix the
   // capitalization anyway, and that's harder to do automatically, since proper names/"I"/etc. stay capitalized.
-  xml = xml.replace(/,” ([A-Za-z]+ [A-Za-z]+), “([A-Z])/ug, ",” $1. “$2");
+  xml = xml.replace(/,” ([A-Za-z]+ [A-Za-z]+), “([A-Z])/vg, ",” $1. “$2");
 
   return xml;
 }
 
 function fixForeignNames(xml) {
   // This is consistently missing diacritics
-  xml = xml.replace(/Yangban/ug, "Yàngbǎn");
+  xml = xml.replace(/Yangban/vg, "Yàngbǎn");
 
   // These are usually not italicized, but sometimes are. Other foreign-language names (like Yàngbǎn) are not
   // italicized, so we go in the direction of removing the italics.
-  xml = xml.replace(/<em>Garama<\/em>/ug, "Garama");
-  xml = xml.replace(/<em>Thanda<\/em>/ug, "Thanda");
-  xml = xml.replace(/<em>Sifara([^<]*)<\/em>/ug, "Sifara$1");
-  xml = xml.replace(/<em>Moord Nag([^<]*)<\/em>/ug, "Moord Nag$1");
-  xml = xml.replace(/<em>Califa de Perro([^<]*)<\/em>/ug, "Califa de Perro$1");
-  xml = xml.replace(/<em>Turanta([^<]*)<\/em>/ug, "Turanta$1");
+  xml = xml.replace(/<em>Garama<\/em>/vg, "Garama");
+  xml = xml.replace(/<em>Thanda<\/em>/vg, "Thanda");
+  xml = xml.replace(/<em>Sifara([^<]*)<\/em>/vg, "Sifara$1");
+  xml = xml.replace(/<em>Moord Nag([^<]*)<\/em>/vg, "Moord Nag$1");
+  xml = xml.replace(/<em>Califa de Perro([^<]*)<\/em>/vg, "Califa de Perro$1");
+  xml = xml.replace(/<em>Turanta([^<]*)<\/em>/vg, "Turanta$1");
 
   return xml;
 }
 
 function standardizeNames(xml) {
   // 197 instances of "Mrs." to 21 of "Ms."
-  xml = xml.replace(/Ms\. Yamada/ug, "Mrs. Yamada");
+  xml = xml.replace(/Ms\. Yamada/vg, "Mrs. Yamada");
 
   // 25 instances of "Amias" to 3 of "Amais"
-  xml = xml.replace(/Amais/ug, "Amias");
+  xml = xml.replace(/Amais/vg, "Amias");
 
   // 185 instances of Juliette to 4 of Juliet
-  xml = xml.replace(/Juliet(?=\b)/ug, "Juliette");
+  xml = xml.replace(/Juliet(?=\b)/vg, "Juliette");
 
   // Earlier chapters have a space; later ones do not. They're separate words, so side with the earlier chapters.
   // One location is missing the "k".
-  xml = xml.replace(/Crock? o[‘’]Shit/ug, "Crock o’ Shit");
+  xml = xml.replace(/Crock? o[‘’]Shit/vg, "Crock o’ Shit");
 
   // 5 instances of "Jotun" to 2 of "Jotunn"
-  xml = xml.replace(/Jotunn/ug, "Jotun");
+  xml = xml.replace(/Jotunn/vg, "Jotun");
 
   // 13 instances of Elman to 1 of Elmann
-  xml = xml.replace(/Elmann/ug, "Elman");
+  xml = xml.replace(/Elmann/vg, "Elman");
 
   // Thousands of instances of Tattletale to 4 instances of Tatteltale
-  xml = xml.replace(/Tatteltale/ug, "Tattletale");
+  xml = xml.replace(/Tatteltale/vg, "Tattletale");
 
   // 73 instances of Über to 2 of Uber
-  xml = xml.replace(/Uber/ug, "Über");
+  xml = xml.replace(/Uber/vg, "Über");
 
   // 5 instances of Johnsonjar to 2 instances of JohnsonJar
-  xml = xml.replace(/JohnsonJar/ug, "Johnsonjar");
+  xml = xml.replace(/JohnsonJar/vg, "Johnsonjar");
 
   // 4 instances of Flying_Kevin to 2 instances of FlyingKevin
-  xml = xml.replace(/FlyingKevin/ug, "Flying_Kevin");
+  xml = xml.replace(/FlyingKevin/vg, "Flying_Kevin");
 
   return xml;
 }
 
 function fixEmDashes(xml) {
-  xml = xml.replace(/ – /ug, "—");
-  xml = xml.replace(/“((?:<em>)?)-/ug, "“$1—");
-  xml = xml.replace(/-[,.]?”/ug, "—”");
-  xml = xml.replace(/-(!|\?)”/ug, "—$1”");
-  xml = xml.replace(/-[,.]?<\/([a-z]+)>”/ug, "—</$1>”");
-  xml = xml.replace(/-“/ug, "—”");
-  xml = xml.replace(/<p>-/ug, "<p>—");
-  xml = xml.replace(/-<\/p>/ug, "—</p>");
-  xml = xml.replace(/-<br \/>/ug, "—<br />");
-  xml = xml.replace(/-<\/([a-z]+)><\/p>/ug, "—</$1></p>");
-  xml = xml.replace(/\s?\s?–\s?\s?/ug, "—");
-  xml = xml.replace(/-\s\s?/ug, "—");
-  xml = xml.replace(/\s?\s-/ug, "—");
-  xml = xml.replace(/\s+—”/ug, "—”");
-  xml = xml.replace(/I-I/ug, "I—I");
-  xml = xml.replace(/I-uh/ug, "I—uh");
-  xml = xml.replace(/-\?/ug, "—?");
+  xml = xml.replace(/ – /vg, "—");
+  xml = xml.replace(/“((?:<em>)?)-/vg, "“$1—");
+  xml = xml.replace(/-[,.]?”/vg, "—”");
+  xml = xml.replace(/-(!|\?)”/vg, "—$1”");
+  xml = xml.replace(/-[,.]?<\/([a-z]+)>”/vg, "—</$1>”");
+  xml = xml.replace(/-“/vg, "—”");
+  xml = xml.replace(/<p>-/vg, "<p>—");
+  xml = xml.replace(/-<\/p>/vg, "—</p>");
+  xml = xml.replace(/-<br \/>/vg, "—<br />");
+  xml = xml.replace(/-<\/([a-z]+)><\/p>/vg, "—</$1></p>");
+  xml = xml.replace(/\s?\s?–\s?\s?/vg, "—");
+  xml = xml.replace(/-\s\s?/vg, "—");
+  xml = xml.replace(/\s?\s-/vg, "—");
+  xml = xml.replace(/\s+—”/vg, "—”");
+  xml = xml.replace(/I-I/vg, "I—I");
+  xml = xml.replace(/I-uh/vg, "I—uh");
+  xml = xml.replace(/-\?/vg, "—?");
 
   return xml;
 }
 
 function enDashJointNames(xml) {
   // Joint names should use en dashes
-  xml = xml.replace(/Dallon-Pelham/ug, "Dallon–Pelham");
-  xml = xml.replace(/Bet-Gimel/ug, "Bet–Gimel");
-  xml = xml.replace(/Cheit-Gimel/ug, "Bet–Gimel");
-  xml = xml.replace(/Tristan-Capricorn/ug, "Tristan–Capricorn");
-  xml = xml.replace(/Capricorn-Byron/ug, "Capricorn–Byron");
-  xml = xml.replace(/Tristan-Byron/ug, "Tristan–Byron");
-  xml = xml.replace(/Gimel-Europe/ug, "Gimel–Europe");
-  xml = xml.replace(/G-N/ug, "G–N");
-  xml = xml.replace(/Imp-Damsel/ug, "Imp–Damsel");
-  xml = xml.replace(/Damsel-Ashley/ug, "Damsel–Ashley");
-  xml = xml.replace(/Antares-Anelace/ug, "Antares–Anelace");
-  xml = xml.replace(/Challenger-Gallant/ug, "Challenger–Gallant");
-  xml = xml.replace(/Undersider(s?)-(Breakthrough|Ambassador)/ug, "Undersider$1–$2");
-  xml = xml.replace(/Norwalk-Fairfield/ug, "Norwalk–Fairfield");
-  xml = xml.replace(/East-West/ug, "east–west");
-  xml = xml.replace(/Creutzfeldt-Jakob/ug, "Creutzfeldt–Jakob");
-  xml = xml.replace(/Astaroth-Nidhug/ug, "Astaroth–Nidhug");
-  xml = xml.replace(/Capulet-Montague/ug, "Capulet–Montague");
-  xml = xml.replace(/Weaver-Clockblocker/ug, "Weaver–Clockblocker");
-  xml = xml.replace(/Alexandria-Pretender/ug, "Alexandria–Pretender");
-  xml = xml.replace(/Night Hag-Nyx/ug, "Night Hag–Nyx");
-  xml = xml.replace(/Crawler-Breed/ug, "Crawler–Breed");
-  xml = xml.replace(/Simurgh-Myrddin-plant/ug, "Simurgh–Myrddin–plant");
-  xml = xml.replace(/Armsmaster-Defiant/ug, "Armsmaster–Defiant");
-  xml = xml.replace(/Matryoshka-Valentin/ug, "Matryoshka–Valentin");
-  xml = xml.replace(/Gaea-Eden/ug, "Gaea–Eden");
-  xml = xml.replace(/([Aa])gent-parahuman/ug, "$1gent–parahuman");
-  xml = xml.replace(/([Pp])arahuman-agent/ug, "$1arahuman–agent");
+  xml = xml.replace(/Dallon-Pelham/vg, "Dallon–Pelham");
+  xml = xml.replace(/Bet-Gimel/vg, "Bet–Gimel");
+  xml = xml.replace(/Cheit-Gimel/vg, "Bet–Gimel");
+  xml = xml.replace(/Tristan-Capricorn/vg, "Tristan–Capricorn");
+  xml = xml.replace(/Capricorn-Byron/vg, "Capricorn–Byron");
+  xml = xml.replace(/Tristan-Byron/vg, "Tristan–Byron");
+  xml = xml.replace(/Gimel-Europe/vg, "Gimel–Europe");
+  xml = xml.replace(/G-N/vg, "G–N");
+  xml = xml.replace(/Imp-Damsel/vg, "Imp–Damsel");
+  xml = xml.replace(/Damsel-Ashley/vg, "Damsel–Ashley");
+  xml = xml.replace(/Antares-Anelace/vg, "Antares–Anelace");
+  xml = xml.replace(/Challenger-Gallant/vg, "Challenger–Gallant");
+  xml = xml.replace(/Undersider(s?)-(Breakthrough|Ambassador)/vg, "Undersider$1–$2");
+  xml = xml.replace(/Norwalk-Fairfield/vg, "Norwalk–Fairfield");
+  xml = xml.replace(/East-West/vg, "east–west");
+  xml = xml.replace(/Creutzfeldt-Jakob/vg, "Creutzfeldt–Jakob");
+  xml = xml.replace(/Astaroth-Nidhug/vg, "Astaroth–Nidhug");
+  xml = xml.replace(/Capulet-Montague/vg, "Capulet–Montague");
+  xml = xml.replace(/Weaver-Clockblocker/vg, "Weaver–Clockblocker");
+  xml = xml.replace(/Alexandria-Pretender/vg, "Alexandria–Pretender");
+  xml = xml.replace(/Night Hag-Nyx/vg, "Night Hag–Nyx");
+  xml = xml.replace(/Crawler-Breed/vg, "Crawler–Breed");
+  xml = xml.replace(/Simurgh-Myrddin-plant/vg, "Simurgh–Myrddin–plant");
+  xml = xml.replace(/Armsmaster-Defiant/vg, "Armsmaster–Defiant");
+  xml = xml.replace(/Matryoshka-Valentin/vg, "Matryoshka–Valentin");
+  xml = xml.replace(/Gaea-Eden/vg, "Gaea–Eden");
+  xml = xml.replace(/([Aa])gent-parahuman/vg, "$1gent–parahuman");
+  xml = xml.replace(/([Pp])arahuman-agent/vg, "$1arahuman–agent");
 
   return xml;
 }
@@ -486,15 +485,19 @@ function fixPossessives(xml) {
   // Fix possessive of names ending in "s".
   xml = xml.replace(
     // eslint-disable-next-line max-len
-    /(?<!‘)(Judas|Brutus|Jess|Aegis|Dauntless|Circus|Sirius|Brooks|Genesis|Atlas|Lucas|Gwerrus|Chris|Eligos|Animos|Mags|Huntress|Hephaestus|Lord of Loss|John Combs|Mama Mathers|Monokeros|Goddess|Boundless|Paris|Tress|Harris|Antares|Nieves|Backwoods|Midas|Mrs. Sims|Ms. Stillons|Chuckles|Amias|Semiramis|Mother of Mothers)’(?!s)/ug,
+    /(?<!‘)(Judas|Brutus|Jess|Aegis|Dauntless|Circus|Sirius|Brooks|Genesis|Atlas|Lucas|Gwerrus|Chris|Eligos|Animos|Mags|Huntress|Hephaestus|Lord of Loss|John Combs|Mama Mathers|Monokeros|Goddess|Boundless|Paris|Tress|Harris|Antares|Nieves|Backwoods|Midas|Mrs. Sims|Ms. Stillons|Chuckles|Amias|Semiramis|Mother of Mothers)’(?!s)/vg,
     "$1’s"
   );
 
   // Note: if the "s" is unvoiced, as in Marquis, then it doesn't get the second "s".
-  xml = xml.replace(/Marquis’s/ug, "Marquis’");
+  xml = xml.replace(/Marquis’s/vg, "Marquis’");
 
-  // This one is not just missing the extra "s"; it's often misplaced.
-  xml = xml.replace(/Warden’s/ug, "Wardens’");
+  // These have their apostrophe misplaced sometimes.
+  xml = xml.replace(/Warden’s/vg, "Wardens’");
+  xml = xml.replace(/Traveller’s/vg, "Travellers’");
+
+  // This is basically a mispelling.
+  xml = xml.replace(/Alzheimers/vg, "Alzheimer’s");
 
   return xml;
 }
@@ -503,23 +506,23 @@ function cleanSceneBreaks(xml) {
   // Normalize scene breaks. <hr> would be more semantically appropriate, but loses the author's intent. This is
   // especially the case in Ward, which uses a variety of different scene breaks.
 
-  xml = xml.replace(/<p(?:[^>]*)>■<\/p>/ug, `<p style="text-align: center;">■</p>`);
+  xml = xml.replace(/<p(?:[^>]*)>■<\/p>/vg, `<p style="text-align: center;">■</p>`);
 
   xml = xml.replace(
-    /<p style="text-align: center;"><strong>⊙<\/strong><\/p>/ug,
+    /<p style="text-align: center;"><strong>⊙<\/strong><\/p>/vg,
     `<p style="text-align: center;">⊙</p>`
   );
   xml = xml.replace(
-    /<p style="text-align: center;"><em><strong>⊙<\/strong><\/em><\/p>/ug,
+    /<p style="text-align: center;"><em><strong>⊙<\/strong><\/em><\/p>/vg,
     `<p style="text-align: center;">⊙</p>`
   );
   xml = xml.replace(
-    /<p style="text-align: center;"><strong>⊙⊙<\/strong><\/p>/ug,
+    /<p style="text-align: center;"><strong>⊙⊙<\/strong><\/p>/vg,
     `<p style="text-align: center;">⊙</p>`
   );
 
   xml = xml.replace(
-    /<p style="text-align: center;"><strong>⊙ *⊙ *⊙ *⊙ *⊙<\/strong><\/p>/ug,
+    /<p style="text-align: center;"><strong>⊙ *⊙ *⊙ *⊙ *⊙<\/strong><\/p>/vg,
     `<p style="text-align: center;">⊙ ⊙ ⊙ ⊙ ⊙</p>`
   );
 
@@ -530,62 +533,63 @@ function fixCapitalization(xml, bookTitle) {
   // This occurs enough times it's better to do here than in one-off fixes. We correct the single instance where
   // it's incorrect to capitalize in the one-off fixes.
   // Note that Ward contains much talk of "the clairvoyants", so we don't want to capitalize plurals.
-  xml = xml.replace(/([Tt])he clairvoyant(?!s)/ug, "$1he Clairvoyant");
+  xml = xml.replace(/([Tt])he clairvoyant(?!s)/vg, "$1he Clairvoyant");
 
   // ReSound's name is sometimes miscapitalized. The word is never used in a non-name context.
-  xml = xml.replace(/Resound/ug, "ReSound");
+  xml = xml.replace(/Resound/vg, "ReSound");
 
   // Number Man's "man" is missing its capitalization a couple times.
-  xml = xml.replace(/Number man/ug, "Number Man");
+  xml = xml.replace(/Number man/vg, "Number Man");
 
   // The Speedrunners team name is missing its capitalization a couple times.
-  xml = xml.replace(/speedrunners/ug, "Speedrunners");
+  xml = xml.replace(/speedrunners/vg, "Speedrunners");
 
   // The Machine Army is missing its capitalization a couple times.
-  xml = xml.replace(/machine army/ug, "Machine Army");
+  xml = xml.replace(/machine army/vg, "Machine Army");
 
   // "patrol block" is capitalized three different ways: "patrol block", "Patrol block", and "Patrol Block". "patrol
   // group" is always lowercased. It seems like "Patrol" is a proper name, and is used as a capitalized modifier in
   // other contexts (e.g. Patrol leader). So let's standardize on "Patrol <lowercase>".
   xml = xml.replace(
-    /patrol (block|group|leader|guard|student|uniform|squad|soldier|officer|crew|girl|bus|training)/uig,
+    /patrol (block|group|leader|guard|student|uniform|squad|soldier|officer|crew|girl|bus|training)/vig,
     (_, $1) => `Patrol ${$1.toLowerCase()}`
   );
   // This usually works in Ward (some instances corrected back in the substitutions file), and has a few false positives
   // in Worm, where it is never needed:
   if (bookTitle === "Ward") {
-    xml = xml.replace(/the patrol(?!s|ling)/ug, "the Patrol");
+    xml = xml.replace(/the patrol(?!s|ling)/vg, "the Patrol");
   }
 
   // This is sometimes missing its capitalization.
-  xml = xml.replace(/the birdcage/ug, "the Birdcage");
+  xml = xml.replace(/the birdcage/vg, "the Birdcage");
 
   // There's no reason why these should be capitalized.
-  xml = xml.replace(/(?<! {2}|“|>)Halberd/ug, "halberd");
-  xml = xml.replace(/(?<! {2}|“|>)Loft/ug, "loft");
+  xml = xml.replace(/(?<! {2}|“|>)Halberd/vg, "halberd");
+  xml = xml.replace(/(?<! {2}|“|>)Loft/vg, "loft");
 
   // These are treated as common nouns and not traditionally capitalized. "Krav Maga" remains capitalized,
   // interestingly (according to dictionaries and Wikipedia).
-  xml = xml.replace(/(?<! {2}|“|>)Judo/ug, "judo");
-  xml = xml.replace(/(?<! {2}|“|>)Aikido/ug, "aikido");
-  xml = xml.replace(/(?<! {2}|“|>)Karate/ug, "karate");
-  xml = xml.replace(/(?<! {2}|“|>)Tae Kwon Do/ug, "tae kwon do");
+  xml = xml.replace(/(?<! {2}|“|>)Judo/vg, "judo");
+  xml = xml.replace(/(?<! {2}|“|>)Aikido/vg, "aikido");
+  xml = xml.replace(/(?<! {2}|“|>)Karate/vg, "karate");
+  xml = xml.replace(/(?<! {2}|“|>)Tae Kwon Do/vg, "tae kwon do");
+  xml = xml.replace(/(?<! {2}|“|>)Track and Field/vg, "track and field");
 
   // There's no reason why university should be capitalized in most contexts, although sometimes it's used as part of
   // a compound noun or at the beginning of a sentence.
-  xml = xml.replace(/(?<! {2}|“|>|Cornell |Nilles )University(?! Road)/ug, "university");
+  xml = xml.replace(/(?<! {2}|“|>|Cornell |Nilles )University(?! Road)/vg, "university");
 
   // Organ names (e.g. brain, arm) or scientific names are not capitalized, so the "corona pollentia" and friends should
   // not be either. The books are inconsistent.
-  xml = xml.replace(/(?<! {2}|“|>|-)Corona/ug, "corona");
-  xml = xml.replace(/Pollentia/ug, "pollentia");
-  xml = xml.replace(/Radiata/ug, "radiata");
-  xml = xml.replace(/Gemma/ug, "gemma");
+  xml = xml.replace(/(?<! {2}|“|>|-)Corona/vg, "corona");
+  xml = xml.replace(/Pollentia/vg, "pollentia");
+  xml = xml.replace(/Radiata/vg, "radiata");
+  xml = xml.replace(/Gemma/vg, "gemma");
 
   // We de-capitalize Valkyrie's "flock", since most uses are de-capitalized (e.g. the many instances in Gleaming
   // Interlude 9, or Dying 15.z). This is a bit surprising; it seems like an organization name. But I guess it's
   // informal.
-  xml = xml.replace(/(?<! {2}|“|>)Flock/ug, "flock");
+  xml = xml.replace(/(?<! {2}|“|>)Flock/vg, "flock");
 
   // Especially early in Worm, PRT designations are capitalized; they should not be. This fixes the cases where we
   // can be reasonably sure they don't start a sentence, although more specific instances are done in the substitutions
@@ -598,64 +602,81 @@ function fixCapitalization(xml, bookTitle) {
   // file.
   xml = xml.replace(
     // eslint-disable-next-line max-len
-    /(?<! {2}|“|>|\n|: )(Mover|Shaker|Brute|Breaker|Tinker|Blaster|Thinker|Striker|Changer|Trump|Stranger|Shifter|Shaper)(?! [A-Z])/ug,
+    /(?<! {2}|“|>|\n|: )(Mover|Shaker|Brute|Breaker|Tinker|Blaster|Thinker|Striker|Changer|Trump|Stranger|Shifter|Shaper)(?! [A-Z])/vg,
     (_, designation) => designation.toLowerCase()
   );
   xml = xml.replace(
-    /(mover|shaker|brute|breaker|tinker|blaster|thinker|master|striker|changer|trump|stranger|shifter|shaper)-(\d+)/ugi,
+    /(mover|shaker|brute|breaker|tinker|blaster|thinker|master|striker|changer|trump|stranger|shifter|shaper)-(\d+)/vig,
     "$1 $2"
   );
   xml = xml.replace(
     // eslint-disable-next-line max-len
-    /(mover|shaker|brute|breaker|tinker|blaster|thinker|master|striker|changer|trump|stranger|shifter|shaper)[ -/](mover|shaker|brute|breaker|tinker|blaster|thinker|master|striker|changer|trump|stranger|shifter|shaper)/ugi,
+    /(mover|shaker|brute|breaker|tinker|blaster|thinker|master|striker|changer|trump|stranger|shifter|shaper)[ -\/](mover|shaker|brute|breaker|tinker|blaster|thinker|master|striker|changer|trump|stranger|shifter|shaper)/vig,
     "$1–$2"
   );
 
   // Capitalization is inconsistent, but shard names seems to usually be capitalized.
-  xml = xml.replace(/Grasping self/ug, "Grasping Self");
-  xml = xml.replace(/Cloven stranger/ug, "Cloven Stranger");
-  xml = xml.replace(/Princess shaper/ug, "Princess Shaper");
-  xml = xml.replace(/Fragile one/ug, "Fragile One");
+  xml = xml.replace(/Grasping self/vg, "Grasping Self");
+  xml = xml.replace(/Cloven stranger/vg, "Cloven Stranger");
+  xml = xml.replace(/Princess shaper/vg, "Princess Shaper");
+  xml = xml.replace(/Fragile one/vg, "Fragile One");
 
   // Place names need to always be capitalized
-  xml = xml.replace(/(Stonemast|Shale) avenue/ug, "$1 Avenue");
-  xml = xml.replace(/(Lord|Slater) street/ug, "$1 Street");
-  xml = xml.replace(/(Hollow|Cedar) point/ug, "$1 Point");
-  xml = xml.replace(/(Norwalk|Fenway|Stratford) station/ug, "$1 Station");
-  xml = xml.replace(/downtown Brockton Bay/ug, "Downtown Brockton Bay");
-  xml = xml.replace(/the megalopolis/ug, "the Megalopolis");
-  xml = xml.replace(/earths(?![a-z])/ug, "Earths");
+  xml = xml.replace(/(Stonemast|Shale) avenue/vg, "$1 Avenue");
+  xml = xml.replace(/(Lord|Slater) street/vg, "$1 Street");
+  xml = xml.replace(/(Hollow|Cedar) point/vg, "$1 Point");
+  xml = xml.replace(/(Norwalk|Fenway|Stratford) station/vg, "$1 Station");
+  xml = xml.replace(/downtown Brockton Bay/vg, "Downtown Brockton Bay");
+  xml = xml.replace(/the megalopolis/vg, "the Megalopolis");
+  xml = xml.replace(/earths(?![a-z])/vg, "Earths");
   if (bookTitle === "Ward") {
-    xml = xml.replace(/the bunker/ug, "the Bunker");
-    xml = xml.replace(/‘bunker’/ug, "‘Bunker’");
+    xml = xml.replace(/the bunker/vg, "the Bunker");
+    xml = xml.replace(/‘bunker’/vg, "‘Bunker’");
   }
+
+  // These seem to be used more as generic terms than as place names.
+  xml = xml.replace(/the Market/vg, "the market");
+  xml = xml.replace(/the Bay(?! [A-Z])/vg, "the bay");
 
   // "Mom" and "Dad" should be capitalized when used as a proper name. These regexps are tuned to catch a good amount of
   // instances, without over-correcting for non-proper-name-like cases. Many other instances are handled in
   // the substitutions file.
-  xml = xml.replace(/(?<!mom), dad(?![a-z])/ug, ", Dad");
-  xml = xml.replace(/, mom(?![a-z-])/ug, ", Mom");
+  xml = xml.replace(/(?<!mom), dad(?![a-z])/vg, ", Dad");
+  xml = xml.replace(/, mom(?![a-z\-])/vg, ", Mom");
+  xml = xml.replace(/\bmy Dad\b/vg, "my dad");
 
   // Similarly, specific aunts and uncles get capitalized when used as a title. These are often missed.
-  xml = xml.replace(/aunt Sarah/ug, "Aunt Sarah");
-  xml = xml.replace(/aunt Fleur/ug, "Aunt Fleur");
-  xml = xml.replace(/uncle Neil/ug, "Uncle Neil");
+  xml = xml.replace(/aunt Sarah/vg, "Aunt Sarah");
+  xml = xml.replace(/aunt Fleur/vg, "Aunt Fleur");
+  xml = xml.replace(/uncle Neil/vg, "Uncle Neil");
 
   // The majority of "Wardens’ headquarters" is lowercased, and always prefixed with "the", indicating it's not a proper
   // place name. So we remove the capitalization in the few places where it does appear.
-  xml = xml.replace(/Wardens’ Headquarters/ug, "Wardens’ headquarters");
+  xml = xml.replace(/Wardens’ Headquarters/vg, "Wardens’ headquarters");
 
   // Some style guides try to reserve capitalized "Nazi" for historical discussions of members of the Nazi party. This
   // seems fuzzy when it comes to phrases like "neo-Nazi", and doesn't seem to be what the author is doing; the books
   // are just plain inconsistent. So, let's standardize on always uppercasing.
-  xml = xml.replace(/(?<![a-z])nazi/ug, "Nazi");
-  xml = xml.replace(/ Neo-/ug, " neo-");
+  xml = xml.replace(/(?<![a-z])nazi/vg, "Nazi");
+  xml = xml.replace(/ Neo-/vg, " neo-");
+
+  // Dog breeds are capitalized only when they derive from proper nouns: "German" in "German shepherd", "Rottweiler"
+  // (from the town of Rottweil).
+  xml = xml.replace(/rottweiler/vg, "Rottweiler");
+  xml = xml.replace(/german shepherd/vig, "German shepherd");
 
   // Style guides disagree on whether items like "english muffin", "french toast", and "french kiss" need their
   // adjective capitalized. The books mostly use lowercase, so let's stick with that. (The substitutions file corrects
   // one case of "French toast".)
-  xml = xml.replace(/english(?! muffin)/ug, "English");
-  xml = xml.replace(/(?<! {2})English muffin/ug, "english muffin");
+  xml = xml.replace(/english(?! muffin)/vg, "English");
+  xml = xml.replace(/(?<! {2})English muffin/vg, "english muffin");
+
+  // Just incorrect
+  xml = xml.replace(/Youtube/vg, "YouTube");
+
+  // Caucasian is a race, and races are often not capitalized (until recent years). But it's derived from a place name,
+  // so it gets capitalized.
+  xml = xml.replace(/caucasian/vg, "Caucasian");
 
   // I was very torn on what to do with capitalization for "Titan" and "Titans". In general you don't capitalize species
   // names or other classifications, e.g. style guides are quite clear you don't capitalize "gods". The author
@@ -667,34 +688,36 @@ function fixCapitalization(xml, bookTitle) {
   // or "Kronos Titan".)
   if (bookTitle === "Ward") {
     // All plural discussions of "Titans" are after Sundown 17.y.
-    xml = xml.replace(/titans/ug, "Titans");
+    xml = xml.replace(/titans/vg, "Titans");
 
     // Since we can't safely change all instances of "titan", most are in the substitutions file. We can do a few here,
     // though.
-    xml = xml.replace(/dauntless titan/uig, "Dauntless Titan"); // Sometimes "Dauntless" isn't even capitalized.
-    xml = xml.replace(/Kronos titan/ug, "Kronos Titan");
+    xml = xml.replace(/dauntless titan/vig, "Dauntless Titan"); // Sometimes "Dauntless" isn't even capitalized.
+    xml = xml.replace(/Kronos titan/vg, "Kronos Titan");
   }
 
   // For the giants, the prevailing usage seems to be to keep the term lowercase, but capitalize when used as a name.
-  xml = xml.replace(/(?<=Mathers |Goddess )giant/ug, "Giant");
-  xml = xml.replace(/mother giant/uig, "Mother Giant");
-  xml = xml.replace(/(?<! {2}|“|>)Giants/ug, "giants");
+  xml = xml.replace(/(?<=Mathers |Goddess )giant/vg, "Giant");
+  xml = xml.replace(/mother giant/vig, "Mother Giant");
+  xml = xml.replace(/(?<! {2}|“|>)Giants/vg, "giants");
 
   return xml;
 }
 
 function fixMispellings(xml) {
   // This is commonly misspelled.
-  xml = xml.replace(/([Ss])houlderblade/ug, "$1houlder blade");
+  xml = xml.replace(/([Ss])houlderblade/vg, "$1houlder blade");
 
   // All dictionaries agree this is capitalized.
-  xml = xml.replace(/u-turn/ug, "U-turn");
+  xml = xml.replace(/u-turn/vg, "U-turn");
 
   // https://www.dictionary.com/browse/scot-free
-  xml = xml.replace(/scott(?: |-)free/ug, "scot-free");
+  xml = xml.replace(/scott(?: |-)free/vg, "scot-free");
 
-  // https://ugrammarist.com/idiom/change-tack/
-  xml = xml.replace(/changed tacks/ug, "changed tack");
+  // https://vgrammarist.com/idiom/change-tack/
+  xml = xml.replace(/changed tacks/vg, "changed tack");
+
+  xml = xml.replace(/gasmask/vg, "gas mask");
 
   return xml;
 }
@@ -702,121 +725,166 @@ function fixMispellings(xml) {
 function fixHyphens(xml) {
   // "X-year-old" should use hyphens; all grammar guides agree. The books are very inconsistent but most often omit
   // them.
-  xml = xml.replace(/(\w+)[ -]year[ -]old(s?)(?!\w)/ug, "$1-year-old$2");
-  xml = xml.replace(/(\w+) or (\w+)-year-old/ug, "$1- or $2-year-old");
+  xml = xml.replace(/(\w+)[ \-]year[ \-]old(s?)(?!\w)/vg, "$1-year-old$2");
+  xml = xml.replace(/(\w+) or (\w+)-year-old/vg, "$1- or $2-year-old");
+
+  // "X-foot-tall" should use hyphens, but we need to avoid "foot taller", "a foot tall", etc.
+  xml = xml.replace(/(?<!a)[ \-]foot[ \-]tall\b/vg, "-foot-tall");
 
   // Compound numbers from 11 through 99 must be hyphenated, but others should not be.
   xml = xml.replace(
     // eslint-disable-next-line max-len
-    /(?<!\w)(twenty|thirty|fourty|fifty|sixty|seventy|eighty|ninety) (one|two|three|four|five|six|seven|eight|nine|something)/uig,
+    /(?<!\w)(twenty|thirty|fourty|fifty|sixty|seventy|eighty|ninety) (one|two|three|four|five|six|seven|eight|nine|something)/vig,
     "$1-$2"
   );
-  xml = xml.replace(/[- ]hundred-and-/ug, " hundred and ");
-  xml = xml.replace(/(?<!-)(one|two|three|four|five|six|seven|eight|nine|twelve)-hundred/ug, "$1 hundred");
-  xml = xml.replace(/(hundred|ninety)-percent(?!-)/ug, "$1 percent");
+  xml = xml.replace(/[ \-]hundred-and-/vg, " hundred and ");
+  xml = xml.replace(/(?<!-)(one|two|three|four|five|six|seven|eight|nine|twelve)-hundred/vg, "$1 hundred");
+  xml = xml.replace(/(hundred|ninety)-percent(?!-)/vg, "$1 percent");
 
   // "red-haired", "long-haired", etc.: they all need hyphens
-  xml = xml.replace(/ haired/ug, "-haired");
+  xml = xml.replace(/ haired/vg, "-haired");
+
+  // Hyphenating types of balls is apparently difficult.
+  xml = xml.replace(/foot-ball/vg, "football");
+  xml = xml.replace(/golf-ball/vg, "golf ball");
 
   // These are consistently missing hyphens.
-  xml = xml.replace(/([Ll]ife) threatening/ug, "life-threatening");
-  xml = xml.replace(/([Hh]ard) headed/ug, "$1-headed");
-  xml = xml.replace(/([Ss]houlder) mounted/ug, "$1-mounted");
-  xml = xml.replace(/([Ss]houlder) length/ug, "$1-length");
+  xml = xml.replace(/(life) (threatening)/vig, "life-threatening");
+  xml = xml.replace(/(hard) (headed)/vig, "$1-$2");
+  xml = xml.replace(/(shoulder) (mounted)/vig, "$1-$2");
+  xml = xml.replace(/(shoulder) (length)/vig, "$1-$2");
+  xml = xml.replace(/(golden|pink|brown|dark|tan|metal|darker|yellow|olive|red|gray) (skinned)/vig, "$1-$2");
+  xml = xml.replace(/(plum|amber|rose|coffee|chestnut|funny|different) (colored)/vig, "$1-$2");
+  xml = xml.replace(/(creepy) (crawl)/vig, "$1-$2");
+  xml = xml.replace(/(well) (armed)/vig, "$1-$2");
+  xml = xml.replace(/(able) (bodied)/vig, "$1-$2");
+  xml = xml.replace(/(level) (headed)/vig, "$1-$2");
+  xml = xml.replace(/(clear) (cut)/vig, "$1-$2");
+  xml = xml.replace(/(vat) (grown)/vig, "$1-$2");
+  xml = xml.replace(/(shell) (shocked)/vig, "$1-$2");
+  xml = xml.replace(/(dog) (tired)/vig, "$1-$2");
+  xml = xml.replace(/(nightmare) (filled)/vig, "$1-$2");
+  xml = xml.replace(/(one) (sided)/vig, "$1-$2");
+  xml = xml.replace(/(medium) (sized)/vig, "$1-$2");
+  xml = xml.replace(/(teary|bright|wide|blue) (eyed)/vig, "$1-$2");
+  xml = xml.replace(/(long|short) (sleeved)/vig, "$1-$2");
+  xml = xml.replace(/(knee) (length|deep)/vig, "$1-$2");
+  xml = xml.replace(/(worst) (case scenario)/vig, "$1-$2");
+  xml = xml.replace(/(government) (sponsored)/vig, "$1-$2");
+  xml = xml.replace(/(high) (pitched)/vig, "$1-$2");
+  xml = xml.replace(/(one) (eyed|eared)/vig, "$1-$2");
+  xml = xml.replace(/(mule) (headed)/vig, "$1-$2");
+  xml = xml.replace(/(fat|squat) (bodied)/vig, "$1-$2");
+  xml = xml.replace(/(self) (conscious|esteem|loathing|harm|destruct|preservation)/vig, "$1-$2");
+  xml = xml.replace(/(one|two|three|four|fourth) (dimensional)/vig, "$1-$2");
+  xml = xml.replace(/(double) (check)/vig, "$1-$2");
+  xml = xml.replace(/(rust) (red)/vig, "$1-$2");
+  xml = xml.replace(/(zig) (zag)/vig, "$1-$2");
+  xml = xml.replace(/(harder) (edged)/vig, "$1-$2");
+  xml = xml.replace(/(so) (called)/vig, "$1-$2");
+  xml = xml.replace(/(mean) (spirited)/vig, "$1-$2");
+  xml = xml.replace(/(full) (fledged|grown)/vig, "$1-$2");
+  xml = xml.replace(/(wide) (reaching)/vig, "$1-$2");
+  xml = xml.replace(/(lesser|better) (known)/vig, "$1-$2");
   xml = xml.replace(
-    /([Gg]olden|[Pp]ink|[Bb]rown|[Dd]ark|[Tt]an|[Mm]etal|[Dd]arker|[Yy]ellow|[Oo]live|[Rr]ed|[Gg]ray) skinned/ug,
-    "$1-skinned"
+    // eslint-disable-next-line max-len
+    /(football|dinner-plate|mountain|island|softball|golf ball|building|Titan|fist|normal|fair|humvee|city|moon|human) (sized)/vig,
+    "$1-$2"
   );
-  xml = xml.replace(/([Cc]reepy) crawl/ug, "$1-crawl");
-  xml = xml.replace(/([Ww]ell) armed/ug, "$1-armed");
-  xml = xml.replace(/([Aa]ble) bodied/ug, "$1-bodied");
-  xml = xml.replace(/([Ll]evel) headed/ug, "$1-headed");
-  xml = xml.replace(/([Cc]lear) cut/ug, "$1-cut");
-  xml = xml.replace(/([Vv]at) grown/ug, "$1-grown");
-  xml = xml.replace(/([Ss]hell) shocked/ug, "$1-shocked");
-  xml = xml.replace(/([Dd]og) tired/ug, "$1-tired");
-  xml = xml.replace(/([Nn]ightmare) filled/ug, "$1-filled");
-  xml = xml.replace(/([Oo]ne) sided/ug, "$1-sided");
-  xml = xml.replace(/([Mm]edium) sized/ug, "$1-sized");
-  xml = xml.replace(/([Tt]eary) eyed/ug, "$1-eyed");
-  xml = xml.replace(/([Ll]ong|[Ss]hort) sleeved/ug, "$1-sleeved");
-  xml = xml.replace(/([Kk]nee) (length|deep)/ug, "$1-$2");
-  xml = xml.replace(/([Ww]orst) case scenario/ug, "$1-case scenario");
-  xml = xml.replace(/([Gg]overnment) sponsored/ug, "$1-sponsored");
-  xml = xml.replace(/([Hh]igh) pitched/ug, "$1-pitched");
-  xml = xml.replace(/([Oo]ne) (eyed|eared)/ug, "$1-$2");
-  xml = xml.replace(/([Ss]elf) (conscious|esteem|loathing|harm|destruct|preservation)/ug, "$1-$2");
-  xml = xml.replace(/([Oo]ne|[Tt]wo|[Tt]hree|[Ff]our|[Ff]ourth) dimensional/ug, "$1-dimensional");
-  xml = xml.replace(/(?<=\b)([Oo]ne) on one(?=\b)/ug, "$1-on-one");
+
+  // When used in attributive position, these are hyphenated. When used in predicate position, style guides vary, but
+  // for consistency we hyphenate.
+  xml = xml.replace(/(middle) (aged)/vig, "$1-$2");
+  xml = xml.replace(/(half) (naked)/vig, "$1-$2");
+  xml = xml.replace(/(old) (fashioned)/vig, "$1-$2");
+
+  // This should be hyphenated only in attributive position, so it's mostly done case-by-case in the substitutions file.
+  // However, "good-looking guy" is used often enough we'll correct it here.
+  xml = xml.replace(/good looking guy/vg, "good-looking guy");
+
+  xml = xml.replace(/(?<=\b)([Oo]ne) on one(?=\b)/vg, "$1-on-one");
+
+  // These need verification to make sure the instances that show up in the text are not nouns performing a past-tense
+  // action. We've verified that for all of these.
+  xml = xml.replace(
+    // eslint-disable-next-line max-len
+    /(human|pear|flower|‘[a-z\-!]+’|almond|teardrop|question mark|slot|cube|comma|star|spade|coin|claw|door) (shaped)/vig,
+    "$1-$2"
+  );
+  // Heart-shaped is special because we don't want to do "Heart Shaped Pupil" (a screen name), so no i flag.
+  xml = xml.replace(/([Hh]eart) (shaped)/vg, "$1-$2");
 
   // Preemptive(ly) is often hyphenated (not always). It should not be.
-  xml = xml.replace(/([Pp])re-emptive/ug, "$1reemptive");
+  xml = xml.replace(/([Pp])re-emptive/vg, "$1reemptive");
 
   // These should be hyphenated only when used as a verb. We correct those cases back in the substitutions file.
-  xml = xml.replace(/fist-bump/ug, "fist bump");
-  xml = xml.replace(/high-five/ug, "high five");
+  xml = xml.replace(/fist-bump/vg, "fist bump");
+  xml = xml.replace(/high-five/vg, "high five");
 
   // This should be hyphenated when used as an adjective (instead of an adverb or noun). I.e. it should be
   // "hand-to-hand combat", but "passed from hand to hand", and "capable in hand to hand". The following heuristic works
   // in the books.
-  xml = xml.replace(/hand to hand(?= [a-z])/ug, "hand-to-hand");
+  xml = xml.replace(/hand to hand(?= [a-z])/vg, "hand-to-hand");
 
   // This is usually wrong but sometimes correct. The lookarounds avoid specific cases where it's referring to an actual
   // second in a series of guesses.
-  xml = xml.replace(/(?<!my |that )([Ss]econd) guess(?!es)/ug, "$1-guess");
+  xml = xml.replace(/(?<!my |that )([Ss]econd) guess(?!es)/vg, "$1-guess");
 
   // When used as a phrase "just in case" gets no hyphens. When used as a noun or adjective it does. A couple of the
   // noun cases are missing one or both hyphens.
-  xml = xml.replace(/([Aa]) just[ -]in case/ug, "$1 just-in-case");
+  xml = xml.replace(/([Aa]) just[ \-]in case/vg, "$1 just-in-case");
 
   // When used as an adjective, it's hyphenated. It turns out most cases are as an adverb, so we go with this approach:
   xml = xml.replace(
-    /face to face(?= meeting| hang-out| interaction| contact| conversation| confrontation| fight)/ug,
+    /face to face(?= meeting| hang-out| interaction| contact| conversation| confrontation| fight)/vg,
     "face-to-face"
   );
 
   // When used as an adjective, it's hyphenated. This heuristic works in the books.
-  xml = xml.replace(/fight or flight(?= [a-z])/ug, "fight-or-flight");
+  xml = xml.replace(/fight or flight(?= [a-z])/vg, "fight-or-flight");
 
   // This is usually correct but sometimes wrong.
-  xml = xml.replace(/neo /ug, "neo-");
+  xml = xml.replace(/neo /vg, "neo-");
 
   return xml;
 }
 
 function standardizeSpellings(xml) {
   // This is usually spelled "TV" but sometimes the other ways. Normalize.
-  xml = xml.replace(/(\b)tv(\b)/ug, "$1TV$2");
-  xml = xml.replace(/t\.v\./uig, "TV");
+  xml = xml.replace(/(\b)tv(\b)/vg, "$1TV$2");
+  xml = xml.replace(/t\.v\./vig, "TV");
 
   // "okay" is preferred to "ok" or "o.k.". This sometimes gets changed back via the substitutions file when people are
   // writing notes and thus probably the intention was to be less formal. Also it seems per
   // https://en.wikipedia.org/wiki/A-ok the "A" in "A-okay" should be capitalized.
-  xml = xml.replace(/Ok([,. ])/ug, "Okay$1");
-  xml = xml.replace(/([^a-zA-Z])ok([^a])/ug, "$1okay$2");
-  xml = xml.replace(/([^a-zA-Z])o\.k\.([^a])/ug, "$1okay$2");
-  xml = xml.replace(/a-okay/ug, "A-okay");
+  xml = xml.replace(/Ok([,. ])/vg, "Okay$1");
+  xml = xml.replace(/([^a-zA-Z])ok([^a])/vg, "$1okay$2");
+  xml = xml.replace(/([^a-zA-Z])o\.k\.([^a])/vg, "$1okay$2");
+  xml = xml.replace(/a-okay/vg, "A-okay");
 
   // Signal(l)ing/signal(l)ed are spelled both ways. Both are acceptable in English. Let's standardize on single-L.
-  xml = xml.replace(/(S|s)ignall/ug, "$1ignal");
+  xml = xml.replace(/(S|s)ignall/vg, "$1ignal");
 
   // Clich(e|é) is spelled both ways. Let's standardize on including the accent.
-  xml = xml.replace(/cliche/ug, "cliché");
+  xml = xml.replace(/cliche/vg, "cliché");
 
   // T-shirt is usually spelled lowercase ("t-shirt"). Normalize the remaining instances.
-  xml = xml.replace(/(?<! {2})T-shirt/ug, "t-shirt");
+  xml = xml.replace(/(?<! {2})T-shirt/vg, "t-shirt");
 
   // "gray" is the majority spelling, except for "greyhound"
-  xml = xml.replace(/(G|g)rey(?!hound)/ug, "$1ray");
+  xml = xml.replace(/(G|g)rey(?!hound)/vg, "$1ray");
+
+  // "changepurse" is the majority spelling
+  xml = xml.replace(/(C|c)hange( |-)purse/vg, "$1hangepurse");
 
   // 12 instances of "Dragon-craft", 12 instances of "Dragon craft", 1 instance of "dragon craft"
-  xml = xml.replace(/[Dd]ragon[ -](craft|mech)/ug, "Dragon-$1");
+  xml = xml.replace(/[Dd]ragon[ \-](craft|mech)/vg, "Dragon-$1");
 
   // 88 instances of "A.I." to four of "AI"
-  xml = xml.replace(/(?<=\b)AI(?=\b)/ug, "A.I.");
+  xml = xml.replace(/(?<=\b)AI(?=\b)/vg, "A.I.");
 
   // 2 instances of "G.M." to one of "GM"
-  xml = xml.replace(/(?<=\b)GM(?=\b)/ug, "G.M.");
+  xml = xml.replace(/(?<=\b)GM(?=\b)/vg, "G.M.");
 
   return xml;
 }
@@ -836,12 +904,12 @@ function fixCaseNumbers(xml) {
   // We standardize on "Case Fifty-Three"; although it isn't the most common, it seems best to treat these as proper
   // nouns.
 
-  xml = xml.replace(/case[ -](?:fifty[ -]three|53)(?!’)/uig, "Case Fifty-Three");
-  xml = xml.replace(/case[ -](?:thirty[ -]two|53)(?!’)/uig, "Case Thirty-Two");
-  xml = xml.replace(/case[ -](?:sixty[ -]nine|53)(?!’)/uig, "Case Sixty-Nine");
+  xml = xml.replace(/case[ \-](?:fifty[ \-]three|53)(?!’)/vig, "Case Fifty-Three");
+  xml = xml.replace(/case[ \-](?:thirty[ \-]two|53)(?!’)/vig, "Case Thirty-Two");
+  xml = xml.replace(/case[ \-](?:sixty[ \-]nine|53)(?!’)/vig, "Case Sixty-Nine");
 
   xml = xml.replace(
-    /(?<!in )case[ -](zero|one|two|three|four|twelve|fifteen|seventy|ninety)(?!-)/uig,
+    /(?<!in )case[ \-](zero|one|two|three|four|twelve|fifteen|seventy|ninety)(?!-)/vig,
     (_, caseNumber) => `Case ${caseNumber[0].toUpperCase()}${caseNumber.substring(1)}`
   );
 
@@ -863,20 +931,20 @@ function fixParahumansOnline(xml) {
     `<p><strong>Welcome to the Parahumans Online message boards.</strong><br />`
   );
   xml = xml.replace(
-    /You are currently logged in, <span style="text-decoration: underline;">([^<]+)<\/span>/ug,
+    /You are currently logged in, <span style="text-decoration: underline;">([^<]+)<\/span>/vg,
     `You are currently logged in, <strong><span style="text-decoration: underline;">$1</span></strong>`
   );
 
   // Most cases have the colon but some don't.
-  xml = xml.replace(/(Replied on \w+ \d{1,2}(?:st|nd|rd|th),? ?Y?\d*)<br \/>/ug, "$1:<br />");
+  xml = xml.replace(/(Replied on \w+ \d{1,2}(?:st|nd|rd|th),? ?Y?\d*)<br \/>/vg, "$1:<br />");
 
   // "You have marked yourself as away." has a period, so this one should too.
-  xml = xml.replace(/(You have marked yourself as back)(?<!\.\s)(?=<br\s*\/?>)/ug, "$1.");
+  xml = xml.replace(/(You have marked yourself as back)(?<!\.\s)(?=<br\s*\/?>)/vg, "$1.");
 
   // It's inconsistent to exclude the punctuation from the bolding; fix it.
-  xml = xml.replace(/<strong>Welcome back to (.+?)<\/strong>!/ug, "<strong>Welcome back to $1!</strong>");
+  xml = xml.replace(/<strong>Welcome back to (.+?)<\/strong>!/vg, "<strong>Welcome back to $1!</strong>");
 
-  xml = xml.replace(/<p>♦ <strong>(.*)<\/strong><\/p>/ug, `<p><strong>♦ $1</strong></p>`);
+  xml = xml.replace(/<p>♦ <strong>(.*)<\/strong><\/p>/vg, `<p><strong>♦ $1</strong></p>`);
 
   return xml;
 }

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -175,6 +175,11 @@ function parseSubstitutions(text) {
           before: beforeAfterLineToString(currentBefore),
           after: beforeAfterLineToString(content)
         };
+
+        if (change.before === change.after) {
+          throw new Error(`${errorPrefix}before and after lines are the same`);
+        }
+
         result.get(currentChapter).push(change);
         currentBefore = null;
 

--- a/substitutions/ward.subs
+++ b/substitutions/ward.subs
@@ -16,6 +16,9 @@
   - and mom being business
   + and Mom being business
 
+  - Are you okay?” the voice was muffled
+  + Are you okay?”  The voice was muffled
+
 
 @ https://www.parahumans.net/2017/11/30/daybreak-1-7/
   - How do you even think rec—how do you think
@@ -103,6 +106,9 @@
   - saying all of that that, he would
   + saying all of that, he would
 
+  - cone or beak shaped
+  + cone- or beak-shaped
+
 
 @ https://www.parahumans.net/2018/01/06/glare-3-1/
   - no longer dominated downtown
@@ -146,6 +152,12 @@
   - say I’m just like mom again
   + say I’m just like Mom again
 
+  - most fucked up person
+  + most fucked-up person
+
+  - really fucked up ones
+  + really fucked-up ones
+
 
 @ https://www.parahumans.net/2018/01/23/glare-3-6/
   - I  had a conversation with dad last night
@@ -158,6 +170,9 @@
 @ https://www.parahumans.net/2018/01/25/glare-interlude-3/
   - much like the the machines
   + much like the machines
+
+  - crazy, fucked up, upside-down, inside-out world
+  + crazy, fucked-up, upside-down, inside-out world
 
 
 @ https://www.parahumans.net/2018/01/30/shade-4-2/
@@ -258,6 +273,17 @@
   - out of the back, “She still would have
   + out of the back, “she still would have
 
+  - a really fucked up thing
+  + a really fucked-up thing
+
+
+@ https://www.parahumans.net/2018/03/13/shadow-interlude-5d/
+  r fucked up snot
+  s fucked-up snot
+
+  - fucked up attitude
+  + fucked-up attitude
+
 
 @ https://www.parahumans.net/2018/03/17/shadow-5-6/
   - have a a specter
@@ -288,6 +314,9 @@
 
   - The convoy continued to disintegrate.  The road as the road made its gradual turn
   + The convoy continued to disintegrate as the road made its gradual turn
+
+  - top notch cooks
+  + top-notch cooks
 
 
 @ https://www.parahumans.net/2018/03/27/shadow-5-10/
@@ -382,6 +411,9 @@
   - The Mcveay’s
   + The McVeays
 
+  - the fucked up bird thing
+  + the fucked-up bird thing
+
 
 @ https://www.parahumans.net/2018/04/21/pitch-6-3/
   - wall of bodies.  the woman behind
@@ -415,6 +447,9 @@
   - Capes converged, ready to guard</p>
   + Capes converged, ready to guard.</p>
 
+  - a fucked up way
+  + a fucked-up way
+
 
 @ https://www.parahumans.net/2018/05/05/pitch-6-7/
   - “—And we wanted to ask for your
@@ -422,6 +457,9 @@
 
   - while you were bloody—I shouldn’t be
   + while you were bloody— I shouldn’t be
+
+  - doing fucked up things
+  + doing fucked-up things
 
 
 @ https://www.parahumans.net/2018/05/08/pitch-6-8/
@@ -437,6 +475,9 @@
   - an Über-neighborhood
   + an uber-neighborhood
   # This seems to lose its umlaut in English; see e.g. https://www.dictionary.com/browse/uber. It's certainly not capitalized.
+
+  - fucked up parahumans
+  + fucked-up parahumans
 
 
 @ https://www.parahumans.net/2018/05/11/pitch-6-9/
@@ -463,6 +504,9 @@
 
   - the Junior Captain said
   + the junior captain said
+
+  - really fucked up stuff
+  + really fucked-up stuff
 
 
 @ https://www.parahumans.net/2018/05/15/torch-7-1/
@@ -624,6 +668,9 @@
 
   - Looksee, You mentioned
   + Looksee, you mentioned
+
+  - ‘defense’ oriented
+  + ‘defense’-oriented
 
 
 @ https://www.parahumans.net/2018/06/19/torch-7-9/
@@ -1184,6 +1231,12 @@
   - Be safe—Nat.
   + Be safe —Nat.
 
+  - quarter-circle shaped
+  + quarter-circle–shaped
+
+  - fucked up people
+  + fucked-up people
+
 
 @ https://www.parahumans.net/2018/11/17/polarize-10-8/
   - Sveta said.  her hand was removed
@@ -1262,6 +1315,9 @@
 
   - how it were more active
   + how it was more active
+
+  - most fucked up corporate capes
+  + most fucked-up corporate capes
 
 
 @ https://www.parahumans.net/2018/12/04/polarize-10-12/
@@ -1453,6 +1509,9 @@
   - backwards-high five
   + backwards high five
 
+  - that fucked up phase
+  + that fucked-up phase
+
 
 @ https://www.parahumans.net/2019/01/26/blinding-11-9/
   - I told the mercenary.”
@@ -1592,6 +1651,9 @@
   - going to mars or some
   + going to Mars or some
 
+  - good looking officer
+  + good-looking officer
+
 
 @ https://www.parahumans.net/2019/02/23/heavens-12-3/
   - had shaken them <em>good-</em> but I could
@@ -1607,6 +1669,9 @@
 
   - closer to haunting, “Think you can
   + closer to haunting, “think you can
+
+  - top notch villains
+  + top-notch villains
 
 
 @ https://www.parahumans.net/2019/03/02/heavens-12-all/
@@ -1666,6 +1731,9 @@
 
   - thinking, the he brushed
   + thinking, then he brushed
+
+  - “What’s going on?” he stood.
+  + “What’s going on?”  He stood.
 
 
 @ https://www.parahumans.net/2019/03/16/heavens-12-7/
@@ -1902,6 +1970,9 @@
   - panic inducing memories
   + panic-inducing memories
 
+  - some fucked up background
+  + some fucked-up background
+
 
 @ https://www.parahumans.net/2019/05/11/black-13-11/
   - been scummy and and tried
@@ -1923,6 +1994,9 @@
 @ https://www.parahumans.net/2019/05/14/13-z/
   - and they were pro-irregular
   + and they were pro-Irregular
+
+  - Her fucked up body
+  + Her fucked-up body
 
 
 @ https://www.parahumans.net/2019/05/18/breaking-14-1/
@@ -2045,6 +2119,9 @@
 
   - claimed more of downtown
   + claimed more of Downtown
+
+  - “Huh?” her voice was quiet
+  + “Huh?”  Her voice was quiet
 
 
 @ https://www.parahumans.net/2019/06/22/breaking-14-11/
@@ -2188,6 +2265,9 @@
   - Caraytid
   + Caryatid
 
+  - good looking preppy cape
+  + good-looking preppy cape
+
 
 @ https://www.parahumans.net/2019/07/20/dying-15-5/
   - worth of of water
@@ -2207,6 +2287,9 @@
 
   - the time manipulating tinkers
   + the time-manipulating tinkers
+
+  - Fucked up ribs
+  + Fucked-up ribs
 
 
 @ https://www.parahumans.net/2019/07/23/dying-15-6/
@@ -2403,6 +2486,9 @@
   - special event space
   + Special event space
 
+  - fucked up system
+  + fucked-up system
+
 
 @ https://www.parahumans.net/2019/09/10/from-within-16-9/
   - changers and and shakers
@@ -2496,6 +2582,9 @@
 
   - day to day work
   + day-to-day work
+
+  - most fucked up thing
+  + most fucked-up thing
 
 
 @ https://www.parahumans.net/2019/09/28/from-within-16-z/
@@ -2601,6 +2690,9 @@
   - call me Big V
   + call me big V
 
+  - this fucked up world
+  + this fucked-up world
+
 
 @ https://www.parahumans.net/2019/10/12/sundown-17-4/
   - on resisting Master influence
@@ -2672,6 +2764,9 @@
   - see the Lab
   + see the lab
 
+  - a fucked up, omnicidal alien
+  + a fucked-up, omnicidal alien
+
 
 @ https://www.parahumans.net/2019/10/26/sundown-17-8/
   - one primary goal—me-, and who
@@ -2711,6 +2806,9 @@
 
   - the south end of the towers
   + the south end of the Towers
+
+  - their fucked up villain group
+  + their fucked-up villain group
 
 
 @ https://www.parahumans.net/2019/11/02/sundown-17-10/
@@ -2794,6 +2892,9 @@
 
   - …The only things that are
   + …the only things that are
+
+  - a fucked up world
+  + a fucked-up world
 
 
 @ https://www.parahumans.net/2019/11/16/radiation-18-1/
@@ -2970,6 +3071,9 @@
 
   - Victoria,” My uncle
   + Victoria,” my uncle
+
+  - massive, fucked up family
+  + massive, fucked-up family
 
 
 @ https://www.parahumans.net/2019/12/10/radiation-18-8/
@@ -3193,6 +3297,9 @@
   - emotion driven
   + emotion-driven
 
+  - in an upside-down, fucked up kind of way
+  + in an upside-down, fucked-up kind of way
+
 
 @ https://www.parahumans.net/2020/01/14/infrared-19-c/
   - <em>-maim, destroy, tear it all down—</em>
@@ -3267,6 +3374,15 @@
 
   - We saw people running around.</p>
   + We saw people running around.”</p>
+
+  - some fucked up bio-altering Titan
+  + some fucked-up bio-altering Titan
+
+  - fucked up leg
+  + fucked-up leg
+
+  - fucked up voice
+  + fucked-up voice
 
 
 @ https://www.parahumans.net/2020/01/25/infrared-19-d/
@@ -3469,6 +3585,12 @@
   - Strikes, brutes, breakers
   + Strikers, brutes, breakers
 
+  - fucked up ribs
+  + fucked-up ribs
+
+  - fucked up collarbone
+  + fucked-up collarbone
+
 
 @ https://www.parahumans.net/2020/03/17/last-20-7/
   - the pain in the ass heroine
@@ -3494,6 +3616,12 @@
 
   - the Entities
   + the entities
+
+  - a fucked up society
+  + a fucked-up society
+
+  - fucked up systems
+  + fucked-up systems
 
 
 @ https://www.parahumans.net/2020/03/24/last-20-9/

--- a/substitutions/worm.subs
+++ b/substitutions/worm.subs
@@ -54,6 +54,12 @@
   - sue you, he gasped
   + sue you,” he gasped
 
+  - the fucked up thing
+  + the fucked-up thing
+
+  - top notch gear
+  + top-notch gear
+
 
 @ https://parahumans.wordpress.com/2011/07/05/insinuation-2-1/
   - “Christ, Taylor,” my father answered, “This isn’t
@@ -272,6 +278,9 @@
   - bus back to the docks
   + bus back to the Docks
 
+  - top notch security systems
+  + top-notch security systems
+
 @ https://parahumans.wordpress.com/2011/08/13/agitation-3-2/
   - were sparring,” Brian told me, “Lisa’s
   + were sparring,” Brian told me.  “Lisa’s
@@ -308,6 +317,33 @@
   - weakness,” Lisa added. “Is
   + weakness,” Lisa added, “is
 
+  - downtown</em>,” Lisa repeated herself, ignoring us, “Then
+  + downtown</em>,” Lisa repeated herself, ignoring us, “then
+
+  - Brian beat me to it, “The risk to reward
+  + Brian beat me to it. “The risk to reward
+
+  - I guarantee you,” Lisa told him, “It’s the
+  + I guarantee you,” Lisa told him.  “It’s the
+
+  - Brian sighed, long and loud, “Well, you got
+  + Brian sighed, long and loud.  “Well, you got
+
+  - realization that I would be up against good guys, “My only
+  + realization that I would be up against good guys.  “My only
+
+  - I didn’t want to get further off topic, “And Vista
+  + I didn’t want to get further off topic.  “And Vista
+
+  - <em>But</em>,” Brian added, wiping a string of cheese from the corner of his lip, “Every time
+  + <em>But</em>,” Brian added, wiping a string of cheese from the corner of his lip, “every time
+
+  - “So that’s the plan, then?” I said, “So many maybes.”
+  + “So that’s the plan, then?” I said.  “So many maybes.”
+
+  - all seriousness,” Brian told me, “If you’re having
+  + all seriousness,” Brian told me, “if you’re having
+
 
 @ https://parahumans.wordpress.com/2011/08/20/agitation-3-4/
   - out?” My
@@ -319,10 +355,31 @@
   - be, tonight, If that’s
   + be, tonight, if that’s
 
+  - “Okay,” my dad said, quietly, “That’s
+  + “Okay,” my dad said, quietly.  “That’s
+
+  - I turned to face Armsmaster, “I’m sorry.
+  + I turned to face Armsmaster.  “I’m sorry.
+
 
 @ https://parahumans.wordpress.com/2011/08/23/agitation-3-5/
   - No,” I said. “I’m
   + No,” I said, “I’m
+
+  - “Yeah,” I tried to sound confident, “But
+  + “Yeah.”  I tried to sound confident.  “But
+
+  - “Why not?” his response was so quick
+  + “Why not?”  His response was so quick
+
+  - “No,” I said, “I’m pretty sure no
+  + “No,” I said.  “I’m pretty sure no
+
+  - god’s honest truth
+  + God’s honest truth
+
+  - man!” Armsmaster bellowed, startling me, “That
+  + man!” Armsmaster bellowed, startling me.  “That
 
 
 @ https://parahumans.wordpress.com/2011/08/27/agitation-3-6/
@@ -335,6 +392,26 @@
   - the midst of downtown
   + the midst of Downtown
 
+  - not sure,” I said, carefully, “That I
+  + not sure,” I said, carefully, “that I
+
+  - started up the car and put it into gear, “Twice, you bring up
+  + started up the car and put it into gear.  “Twice, you bring up
+
+  - through our veins,” Lisa’s voice was barely above a whisper, “Now tell
+  + through our veins.”  Lisa’s voice was barely above a whisper.  “Now tell
+
+
+@ https://parahumans.wordpress.com/2011/08/30/agitation-3-7/
+  - his power to play with the sound, “Tattletale,
+  + his power to play with the sound.  “Tattletale,
+
+  - keypad, staring at it, “Every employee
+  + keypad, staring at it.  “Every employee
+
+  - Your move, Bug girl
+  + Your move, bug girl
+
 
 @ https://parahumans.wordpress.com/2011/09/03/agitation-3-8/
   - direction</p>
@@ -342,6 +419,30 @@
 
   - had in her and and stood up
   + had in her hand and stood up
+
+  - papers into place, “And we
+  + papers into place.  “And we
+
+  - Too many teeth showing, I suppressed a shiver
+  + Too many teeth showing.  I suppressed a shiver
+
+  - if she got aggressive, “Just trying to
+  + if she got aggressive.  “Just trying to
+
+  - “Tattletale,” Grue growled in his echoing, reveberating voice, “You know
+  + “Tattletale,” Grue growled in his echoing, reverberating voice, “you know
+
+  - well in advance,” Grue hissed at her, “And there’s
+  + well in advance,” Grue hissed at her.  “And there’s
+
+  - seven!” Grue roared in his unearthly voice “There’s
+  + seven!” Grue roared in his unearthly voice.  “There’s
+
+  - guess,” Tattletale spoke in a low voice, “I was
+  + guess,” Tattletale spoke in a low voice.  “I was
+
+  - one piece,” Grue spoke, his tone low and menacing, “We’re going
+  + one piece,” Grue spoke, his tone low and menacing, “we’re going
 
 
 @ https://parahumans.wordpress.com/2011/09/06/agitation-3-9/
@@ -351,6 +452,9 @@
   - before she made made her way back
   + before she made her way back
 
+  - spit it out,” Grue spoke in his echoing voice, “We need
+  + spit it out,” Grue spoke in his echoing voice.  “We need
+
 
 @ https://parahumans.wordpress.com/2011/09/10/agitation-3-10/
   - meaning his aim was
@@ -359,13 +463,43 @@
   - The scant few that that remained
   + The scant few that remained
 
+  - more a very large person someone hitting a punching
+  + more like a very large person hitting a punching
+
 
 @ https://parahumans.wordpress.com/2011/09/13/agitation-3-11/
   - weapon of all,“ Tattletale purred
   + weapon of all,” Tattletale purred
 
   - now,” the lie was
-  + now.” The lie was
+  + now.”  The lie was
+
+  - the pain making my voice strained, harder-edged, “What the
+  + the pain making my voice strained, harder-edged.  “What the
+
+  - to look at the brown-haired girl, “You okay?”
+  + to look at the brown-haired girl.  “You okay?”
+
+  - isn’t it?” then in a lower voice,
+  + isn’t it?”  Then in a lower voice,
+
+  - but noooo,” Glory Girl said, “You needed
+  + but noooo,” Glory Girl said, “you needed
+
+  - stayed back,” I warned her, “You get
+  + stayed back,” I warned her.  “You get
+
+  - drawer,” Glory Girl threatened, “And I’ll
+  + drawer,” Glory Girl threatened, “and I’ll
+
+  - “Right,” Glory Girl agreed, “Always
+  + “Right,” Glory Girl agreed.  “Always
+
+  - Tattletale, I see,” Glory Girl was saying, “But
+  + Tattletale, I see,” Glory Girl was saying.  “But
+
+  - Tattletale purred, smiling wickedly, “Information.”
+  + Tattletale purred, smiling wickedly.  “Information.”
 
 
 @ https://parahumans.wordpress.com/2011/09/17/agitation-3-12/
@@ -378,6 +512,15 @@
   - leisurely through downtown
   + leisurely through Downtown
 
+  - toddler,” Tattletale grinned at Panacea, “Given
+  + toddler,” Tattletale grinned at Panacea.  “Given
+
+  - the Birdcage,” Glory Girl promised, “You know
+  + the Birdcage,” Glory Girl promised.  “You know
+
+  - “Help me stand,” Tattletale’s voice was strained, “Using my
+  + “Help me stand.”  Tattletale’s voice was strained.  “Using my
+
 
 @ https://parahumans.wordpress.com/2011/09/20/interlude-3-2/
   - guys,” Gallant said. “Before
@@ -385,6 +528,51 @@
 
   - tinker created
   + tinker-created
+
+  - raised a fraction, “You look
+  + raised a fraction.  “You look
+
+  - wrong,” Piggot told him, “Fact of
+  + wrong,” Piggot told him.  “Fact of
+
+  - Class A threat,” Kid Win said, “Getting rid
+  + Class A threat,” Kid Win said.  “Getting rid
+
+  - Browbeat spoke up for the first time, “I don’t
+  + Browbeat spoke up for the first time.  “I don’t
+
+  - thought,” Gallant told their newest member, “Hey Clock
+  + thought,” Gallant told their newest member.  “Hey Clock
+
+  - mantle to you,” Clockblocker smiled self deprecatingly, “No worries.
+  + mantle to you.”  Clockblocker smiled self-deprecatingly.  “No worries.
+
+  - “Girl,” Clockblocker corrected him, “I was talking
+  + “Girl,” Clockblocker corrected him.  “I was talking
+
+  - it’s good enough,” Gallant wrote the name up on the whiteboard, “Now
+  + it’s good enough.”  Gallant wrote the name up on the whiteboard.  “Now
+
+  - “Armsmaster,” Gallant stood up, “Good to see you
+  + “Armsmaster,” Gallant stood up, “good to see you
+
+  - told the young heroes, “Can’t send
+  + told the young heroes.  “Can’t send
+
+  - my rescue,” Panacea spoke, shyly, “And for letting
+  + my rescue,” Panacea spoke, shyly.  “And for letting
+
+  - “It’s fine,” Miss Militia interrupted him, “Amy,
+  + “It’s fine,” Miss Militia interrupted him.  “Amy,
+
+  - then turned to the group, “Who needs
+  + then turned to the group.  “Who needs
+
+  - with a touch of bitterness, “Do you
+  + with a touch of bitterness.  “Do you
+
+  - the rest of my family,” Amy hugged
+  + the rest of my family.”  Amy hugged
 
 
 @ https://parahumans.wordpress.com/2011/09/24/shell-4-1/
@@ -394,10 +582,40 @@
   - make sense for him to to pull a fast one
   + make sense for him to pull a fast one
 
+  - thing is,” I replied, turning my attention back to my notebook, “You’re
+  + thing is,” I replied, turning my attention back to my notebook, “you’re
+
+  - one and a half page story
+  + one-and-a-half-page story
+
 
 @ https://parahumans.wordpress.com/2011/09/27/shell-4-2/
   - Fugly Bobs
   + Fugly Bob’s
+
+  - the group dynamic,” she led me to a
+  + the group dynamic.”  She led me to a
+
+  - detail oriented
+  + detail-oriented
+
+  - keep my voice calm, “But you interfere
+  + keep my voice calm.  “But you interfere
+
+  - looked a little hurt, “Fine.”
+  + looked a little hurt.  “Fine.”
+
+  - nag,” Brian said, eyeing the piles of bags, “But
+  + nag,” Brian said, eyeing the piles of bags, “but
+
+  - cool,” Lisa brushed him off, “It only
+  + cool,” Lisa brushed him off.  “It only
+
+  - terms of our,” I lowered my voice, “Illicit activity
+  + terms of our,” I lowered my voice, “illicit activity
+
+  - any consolation,” I said, after taking a bite and wiping my mouth with a napkin, “This is
+  + any consolation,” I said, after taking a bite and wiping my mouth with a napkin, “this is
 
 
 @ https://parahumans.wordpress.com/2011/10/01/shell-4-3/
@@ -409,6 +627,27 @@
 
   - story,” I said. “But
   + story,” I said, “but
+
+  - “Why?” I asked, “Why do
+  + “Why?” I asked.  “Why do
+
+  - “Basically,” Alec said. “For your
+  + “Basically,” Alec said, “for your
+
+  - okay,” Brian reassured me, “It’s one
+  + okay,” Brian reassured me.  “It’s one
+
+  - on what it was,” I managed to say, “I dunno
+  + on what it was,” I managed to say.  “I dunno
+
+  - their fucked up biology into my head.
+  + their fucked up biology into my head.”
+
+  - statement carried some finality, “There’s too
+  + statement carried some finality.  “There’s too
+
+  - their fucked up biology
+  + their fucked-up biology
 
 
 @ https://parahumans.wordpress.com/2011/10/04/shell-4-4/
@@ -424,10 +663,34 @@
   - Actually,” he paused. “You’re
   + Actually,” he paused, “you’re
 
+  - earlier,” Lisa assured him, “He has
+  + earlier,” Lisa assured him, “he has
+
+  - woah,” Alec cut in, “Tens of thousands
+  + woah,” Alec cut in.  “Tens of thousands
+
+  - widow spiders?” Alec groaned, “This is the
+  + widow spiders?” Alec groaned.  “This is the
+
+  - get ready,” Brian directed us, “We told our employer
+  + get ready,” Brian directed us.  “We told our employer
+
+  - perfect,” I interrupted him, “Really.
+  + perfect,” I interrupted him.  “Really.
+
+  - think…” Brian said, weighing his words carefully, “It would be
+  + think…” Brian said, weighing his words carefully, “it would be
+
+  - fucked up boyfriends
+  + fucked-up boyfriends
+
 
 @ https://parahumans.wordpress.com/2011/10/08/shell-4-5/
   - money,” Grue spoke. “Where
   + money,” Grue spoke, “where
+
+  - as if she was focusing on something else, “Someone
+  + as if she was focusing on something else.  “Someone
 
 
 @ https://parahumans.wordpress.com/2011/10/11/shell-4-6/
@@ -440,6 +703,12 @@
   - Thanks,” I huffed. “For
   + Thanks,” I huffed, “for
 
+  - in his characteristically overdramatic tone, “It’s a
+  + in his characteristically overdramatic tone.  “It’s a
+
+  - Tattletale was the first to put a name to the face, “Fuck me
+  + Tattletale was the first to put a name to the face.  “Fuck me
+
 
 @ https://parahumans.wordpress.com/2011/10/11/interlude-3%C2%BD-bonus/
   - Korean girls were
@@ -451,6 +720,15 @@
   - offer is this:  Let me
   + offer is this: let me
 
+  - Twice, she circled around the top floors of the wrong buildings, looking for the logo set on the side of the building would mark Max’s building apart from the others.
+  + Twice, she circled around the top floors of the wrong buildings, looking for the logo set on the side that would mark Max’s building apart from the others.
+
+  - Kayden,” he said, when he’d stopped, “You’re already
+  + Kayden,” he said, when he’d stopped, “you’re already
+
+  - hint of condescension in his voice, “You left my team
+  + hint of condescension in his voice.  “You left my team
+
 
 @ https://parahumans.wordpress.com/2011/10/15/shell-4-7/
   - soldiers; Every
@@ -458,6 +736,12 @@
 
   - Again,” I panted. “Over
   + Again,” I panted, “over
+
+  - have to move,” Grue urged us, “This gets
+  + have to move,” Grue urged us.  “This gets
+
+  - if she misses,” Grue shook his head, “We don’t
+  + if she misses.”  Grue shook his head.  “We don’t
 
 
 @ https://parahumans.wordpress.com/2011/10/18/shell-4-8/
@@ -467,6 +751,30 @@
   - ’Kay
   + ’kay
 
+  - this,” Tattletale spoke very carefully, “You were
+  + this,” Tattletale spoke very carefully.  “You were
+
+  - and she released him, “But it goes further
+  + and she released him.  “But it goes further
+
+  - easy for you,” Bakuda might have been
+  + easy for you.”  Bakuda might have been
+
+  - kind of inflection, “You don’t even
+  + kind of inflection.  “You don’t even
+
+  - have been a prayer, “Please.
+  + have been a prayer.  “Please.
+
+  - looks than Bakuda had with her laugh
+  + looks as Bakuda had with her laugh
+
+  - of the Jeep, “Am sitting
+  + of the Jeep, “am sitting
+
+  - concludes my demonstration,” Bakuda addressed our
+  + concludes my demonstration.”  Bakuda addressed our
+
 
 @ https://parahumans.wordpress.com/2011/10/22/shell-4-9/
   - big one: She’s
@@ -474,6 +782,12 @@
 
   - No,” I answered. “No worries
   + No,” I answered, “no worries
+
+  - had something to add, “The first
+  + had something to add.  “The first
+
+  - that fucked up situation
+  + that fucked-up situation
 
 
 @ https://parahumans.wordpress.com/2011/10/29/shell-4-11/
@@ -489,10 +803,37 @@
   - Brian looked across the room,” We’ve
   + Brian looked across the room.  “We’ve
 
+  - dad spoke, hesitantly, “But even after
+  + dad spoke, hesitantly.  “But even after
+
+@ https://parahumans.wordpress.com/2011/11/01/interlude-4-2/
+  - It’s not… no, nevermind.
+  + It’s not…  No, nevermind.
+
 
 @ https://parahumans.wordpress.com/2011/11/05/hive-5-1/
   - half of downtown
   + half of Downtown
+
+  - No, Skitter,” Tattletale nudged me, “She’s deaf
+  + No, Skitter.”  Tattletale nudged me.  “She’s deaf
+
+  - yes?” Coil spoke, his voice smooth, “You’re
+  + yes?” Coil spoke, his voice smooth.  “You’re
+
+  - hand individually, “We’re in agreement?
+  + hand individually, “we’re in agreement?
+
+  - top notch personnel
+  + top-notch personnel
+
+  - highest end gear
+  + highest-end gear
+
+
+@ https://parahumans.wordpress.com/2011/11/08/hive-5-2/
+  - this up,” I informed the others, “Eyes
+  + this up,” I informed the others.  “Eyes
 
 
 @ https://parahumans.wordpress.com/2011/11/12/hive-5-3/
@@ -504,6 +845,27 @@
 
   - day to day basis
   + day-to-day basis
+
+  - two capes; Battery and Shadow Stalker
+  + two capes: Battery and Shadow Stalker
+
+  - while she… ah, here she is
+  + while she…  Ah, here she is
+
+  - diet sprite
+  + Diet Sprite
+
+  - touch, Danny,” Emma’s dad smiled, “Maybe you
+  + touch, Danny.”  Emma’s dad smiled.  “Maybe you
+
+  - here for the sales,” Alan chuckled a little, “My daughter
+  + here for the sales.”  Alan chuckled a little.  “My daughter
+
+  - Taylor,” my dad said, looking drained, “Do as she
+  + Taylor,” my dad said, looking drained, “do as she
+
+  - Please, miss,” my dad said, “This isn’t
+  + Please, miss,” my dad said, “this isn’t
 
 
 @ https://parahumans.wordpress.com/2011/11/15/hive-5-4/
@@ -525,6 +887,30 @@
   - ‘specially with
   + ’Specially with
 
+  - accounts from hotmail and yahoo
+  + accounts from Hotmail and Yahoo!
+
+  - No,” the principal spoke, “But I think
+  + No,” the principal spoke, “but I think
+
+  - wryly commented, “And if
+  + wryly commented.  “And if
+
+  - fail the year,” the principal stated, “I don’t think
+  + fail the year,” the principal stated.  “I don’t think
+
+  - justice here?” I replied, “I’m not
+  + justice here?” I replied.  “I’m not
+
+  - weapon to school,” I said, glaring at them, “If I threatened
+  + weapon to school,” I said, glaring at them.  “If I threatened
+
+  - shut up,” my dad growled, “My daughter
+  + shut up,” my dad growled.  “My daughter
+
+  - circumstances,” my dad protested, “She has
+  + circumstances,” my dad protested.  “She has
+
 
 @ https://parahumans.wordpress.com/2011/11/19/hive-5-5/
   - group: The
@@ -532,6 +918,25 @@
 
   - No,” I admitted. “Not
   + No,” I admitted, “not
+
+  - No,” I stopped her, “It’s not
+  + No,” I stopped her, “it’s not
+
+
+@ https://parahumans.wordpress.com/2011/11/22/hive-5-6/
+  - cover of the alleyway, “Attack from another
+  + cover of the alleyway.  “Attack from another
+
+  - kill anyone,” Newter said, checking his watch again, “Five seconds
+  + kill anyone,” Newter said, checking his watch again.  “Five seconds
+
+
+@ https://parahumans.wordpress.com/2011/11/26/hive-5-7/
+  - At my command, The bugs
+  + At my command, the bugs
+
+  - where he’s teleporting,” I told her, “Get Judas
+  + where he’s teleporting,” I told her.  “Get Judas
 
 
 @ https://parahumans.wordpress.com/2011/11/29/hive-5-8/
@@ -575,6 +980,24 @@
   - day to day interactions
   + day-to-day interactions
 
+  - some fucked up people
+  + some fucked-up people
+
+  - I repeat,” I ignored her, “He’s drugged and blinded
+  + I repeat,” I ignored her, “he’s drugged and blinded
+
+  - He’ll heal,” I pointed out, “Eventually
+  + He’ll heal,” I pointed out.  “Eventually
+
+  - fucks up your body,” he gestured to himself using his tail, which was still holding the paper bags, “Sometimes it
+  + fucks up your body.”  He gestured to himself using his tail, which was still holding the paper bags.  “Sometimes it
+
+  - your neck,” she looked bothered, “People
+  + your neck.”  She looked bothered.  “People
+
+  - already said that,” she switched from looking bothered to looking angry, “It’s mine
+  + already said that.”  She switched from looking bothered to looking angry.  “It’s mine
+
 
 @ https://parahumans.wordpress.com/2011/12/10/interlude-5/
   - bullshit, of course, he
@@ -586,6 +1009,27 @@
   - it is,” Faultline explained. “Whether
   + it is,” Faultline explained, “whether
 
+  - “Really?” the guy rubbed his chin, “For how long?”
+  + “Really?”  The guy rubbed his chin.  “For how long?”
+
+  - can see,” Gregor said, without any affectation, “It would be
+  + can see,” Gregor said, without any affectation, “it would be
+
+  - the owner’s brother, fuckwit,” the doorman told her, “Out of the line.
+  + the owner’s brother, fuckwit,” the doorman told her.  “Out of the line.
+
+  - right there,” Newter pointed to the spoon with the tip of his tail, “Is a little less
+  + right there,” Newter pointed to the spoon with the tip of his tail, “is a little less
+
+  - Elle,” he spoke, gently, “May I come
+  + Elle,” he spoke, gently.  “May I come
+
+  - her professional clothes; a white dress shirt
+  + her professional clothes: a white dress shirt
+
+  - attractive hand,” he examined the hand he’d just used to strangle Faultline, “To lose it
+  + attractive hand.”  He examined the hand he’d just used to strangle Faultline.  “To lose it
+
 
 @ https://parahumans.wordpress.com/2011/12/13/tangle-6-1/
   - <em>me</em>,” she
@@ -596,6 +1040,12 @@
 
   - After mom died
   + After Mom died
+
+  - less than enthusiastic recruits
+  + less-than-enthusiastic recruits
+
+  - For now,” Brian pointed out, “We still
+  + For now,” Brian pointed out.  “We still
 
 
 @ https://parahumans.wordpress.com/2011/12/17/tangle-6-2/
@@ -623,6 +1073,15 @@
   - other buildings of downtown
   + other buildings of Downtown
 
+  - about the guys’ more disgusting and degrading
+  + about the guy’s more disgusting and degrading
+
+  - I looked at the top, it had a thick
+  + I looked at the top.  It had a thick
+
+  - the stuff I’d left on the bed, “Brian’s a guy
+  + the stuff I’d left on the bed.  “Brian’s a guy
+
 
 @ https://parahumans.wordpress.com/2011/12/20/tangle-6-3/
   - black leather  Not that
@@ -643,6 +1102,30 @@
   - sure,” I had
   + sure.” I had
 
+  - a floor to ceiling window
+  + a floor-to-ceiling window
+
+  - thanks,” he replied, after a second, “Want to
+  + thanks,” he replied, after a second.  “Want to
+
+  - Aisha,” Brian stood up, “What are you
+  + Aisha,” Brian stood up, “what are you
+
+  - Laborn?” the heavy woman said, “I’m afraid
+  + Laborn?” the heavy woman said.  “I’m afraid
+
+  - I might have said yes,” Brian told her, “Now I’m
+  + I might have said yes,” Brian told her.  “Now I’m
+
+  - So,” Brian spoke to Mrs. Henderson,  “You wanted
+  + So,” Brian spoke to Mrs. Henderson, “you wanted
+
+  - And,” she said, turning to Brian, “You might want your
+  + And,” she said, turning to Brian, “you might want your
+
+  - Sorry,” he made a pained face, “If I thought
+  + Sorry.”  He made a pained face.  “If I thought
+
 
 @ https://parahumans.wordpress.com/2011/12/24/tangle-6-4/
   - understand,” Lisa sighed. “I
@@ -651,20 +1134,68 @@
   - ’embarrass them’
   + ‘embarrass them’
 
+  - necessarily,” Lisa shook her head, “Five minutes
+  + necessarily.”  Lisa shook her head.  “Five minutes
+
+  - little crazy than me,” Alec told Lisa, “But I’m
+  + little crazy than me,” Alec told Lisa, “but I’m
+
+  - I said,” Lisa smiled a little, “Biggest job
+  + I said,” Lisa smiled a little, “biggest job
+
+  - admit,” Brian conceded. “I <em>am</em> curious.
+  + admit,” Brian conceded, “I <em>am</em> curious.
+
 
 @ https://parahumans.wordpress.com/2011/12/27/tangle-6-5/
   - Architecture
   + architecture
 
+  - crossed the event horizon, it was do or die
+  + crossed the event horizon; it was do or die
 
-@ https://parahumans.wordpress.com/2011/12/31/tangle-6-6/
+  - Regent, go!” He shouted
+  + Regent, go!” he shouted
+
+
+@ https://parahumans.wordpress.com/2011/g12/31/tangle-6-6/
   - Somehow,” Grue retorted. “I’m
   + Somehow,” Grue retorted, “I’m
+
+  - top notch costume designers
+  + top-notch costume designers
+
+  - Armsmaster glanced my way, “And the
+  + Armsmaster glanced my way.  “And the
+
+  - treatment we’ll get!?” Regent shouted, “It’s not
+  + treatment we’ll get!?” Regent shouted.  “It’s not
+
+  - teammate’s throat,” Grue broke the silence, “I think
+  + teammate’s throat,” Grue broke the silence.  “I think
+
+  - your antics tonight,” he shook his head, “A bird in the
+  + your antics tonight.”  He shook his head.  “A bird in the
 
 
 @ https://parahumans.wordpress.com/2012/01/03/tangle-6-7/
   - people in the downtown area
   + people in the Downtown area
+
+  - stop here?” Tattletale murmured to us, “We’re, like
+  + stop here?” Tattletale murmured to us.  “We’re, like
+
+  - Right,” Regent’s voice was thick with sarcasm, “Because this
+  + Right.”  Regent’s voice was thick with sarcasm.  “Because this
+
+  - forcefield was generating, “He hates
+  + forcefield was generating.  “He hates
+
+  - this garage,” Armsmaster informed us, “The doors
+  + this garage,” Armsmaster informed us.  “The doors
+
+  - could think was <em>this is it.
+  + could think was <em>This is it.
 
 
 @ https://parahumans.wordpress.com/2012/01/07/tangle-6-8/
@@ -676,6 +1207,24 @@
 
   - the North end
   + the North End
+
+  - distinctive enough that it Could make us
+  + distinctive enough that it could make us
+
+  - I wish,” Coil told us, “To perform
+  + I wish,” Coil told us, “to perform
+
+  - Grue and face me, “No.
+  + Grue and face me.  “No.
+
+  - That guy,” Trickster tilted his head in Coil’s direction, “Is offering my team
+  + That guy,” Trickster tilted his head in Coil’s direction, “is offering my team
+
+  - So,” Grue spoke to Coil, “You’ve provoked
+  + So,” Grue spoke to Coil, “you’ve provoked
+
+  - to avoid alerting Tattletale, “You want
+  + to avoid alerting Tattletale.  “You want
 
 
 @ https://parahumans.wordpress.com/2012/01/10/tangle-6-9/
@@ -699,6 +1248,15 @@
 
   - envelope</p>
   + envelope.</p>
+
+  - “Did you say something?” my dad looked up from his book
+  + “Did you say something?”  My dad looked up from his book
+
+  - out for him,” she had replied, “And anyone
+  + out for him,” she had replied.  “And anyone
+
+  - prisoner,” I replied, letting anger and hurt creep into my voice, “Do you
+  + prisoner,” I replied, letting anger and hurt creep into my voice.  “Do you
 
 
 @ https://parahumans.wordpress.com/2012/01/14/interlude-6/
@@ -729,6 +1287,19 @@
   - Master 8
   + master eight
 
+  - Some are quite lethal.”</p>\n<p>“These are
+  + Some are quite lethal.</p>\n<p>“These are
+
+  - is much higher.”</p>\n<p>“Know that
+  + is much higher.</p>\n<p>“Know that
+
+  - go one way.  Down.”</p>\n<p>“I will be depositing you
+  + go one way.  Down.</p>\n<p>“I will be depositing you
+
+  - directionis
+  + directions
+
+
 
 @ https://parahumans.wordpress.com/2012/01/17/buzz-7-1/
   - reservations,” Brian spoke. “But
@@ -736,6 +1307,9 @@
 
   - &amp;
   + and
+
+  - fucked up circumstances
+  + fucked-up circumstances
 
 
 @ https://parahumans.wordpress.com/2012/01/24/buzz-7-3/
@@ -780,6 +1354,9 @@
 
   - throat, “Kiss
   + throat, “kiss
+
+  - good looking girl
+  + good-looking girl
 
 
 @ https://parahumans.wordpress.com/2012/02/07/buzz-7-7/
@@ -1320,6 +1897,9 @@
   - of this</em> guy.
   + of this guy.</em>
 
+  - fucked up set of priorities
+  + fucked-up set of priorities
+
 
 @ https://parahumans.wordpress.com/2012/04/14/sentinel-9-4/
   - more focused one</em>.</p>
@@ -1594,6 +2174,9 @@
   - wanted to say, “We’re already
   + wanted to say. “We’re already
 
+  - really fucked up prom
+  + really fucked-up prom
+
 
 @ https://parahumans.wordpress.com/2012/06/02/infestation-11-5/
   - he hollered, “Whoever
@@ -1710,6 +2293,9 @@
   - goals…” she winced, pressed one hand to her stomach, “Coincide
   + goals…” She winced, pressed one hand to her stomach. “…coincide
 
+  - would give him a half-hour to an hour
+  + would give him a half hour to an hour
+
 
 @ https://parahumans.wordpress.com/2012/06/21/interlude-11f/
   - my ‘candy</em>‘
@@ -1723,6 +2309,9 @@
 
   - “I’m sorry,” A girl’s
   + “I’m sorry,” a girl’s
+
+  - die in the next half-hour
+  + die in the next half hour
 
 
 @ https://parahumans.wordpress.com/2012/06/22/interlude-11g/
@@ -1749,6 +2338,12 @@
 
   - <em>Ça va?</em>
   + <i>Ça va?</i>
+
+  - fucked up people
+  + fucked-up people
+
+  - fucked up city
+  + fucked-up city
 
 
 @ https://parahumans.wordpress.com/2012/06/23/interlude-11h/
@@ -1943,6 +2538,9 @@
   - the downtown areas
   + the Downtown areas
 
+  - fucked up idea
+  + fucked-up idea
+
 
 @ https://parahumans.wordpress.com/2012/07/31/snare-13-2/
   - nice part of downtown
@@ -1952,6 +2550,12 @@
 @ https://parahumans.wordpress.com/2012/08/02/interlude-13%C2%BD-donation-bonus/
   - hon,” Celia said. “We’ve
   + hon,” Celia said, “we’ve
+
+  - fucked up kid
+  + fucked-up kid
+
+  - was good-looking for her age
+  + was good looking for her age
 
 
 @ https://parahumans.wordpress.com/2012/08/14/snare-13-6/
@@ -1993,6 +2597,9 @@
 
   - upfront,” he said. “I
   + upfront,” he said, “I
+
+  - fucked up plan
+  + fucked-up plan
 
 
 @ https://parahumans.wordpress.com/2012/09/04/prey-14-1/
@@ -2095,6 +2702,11 @@
   + here?</em> he
 
 
+@ https://parahumans.wordpress.com/2012/10/16/colony-15-1/
+  - about a half-hour of walking a day
+  + about a half hour of walking a day
+
+
 @ https://parahumans.wordpress.com/2012/10/20/colony-15-2/
   - turned something
   + taken something
@@ -2124,6 +2736,9 @@
   - dishonest members
   + dishonest member
   # He's talking only about Skitter here.
+
+  - You’re good-looking, and you
+  + You’re good looking, and you
 
 
 @ https://parahumans.wordpress.com/2012/10/27/colony-15-4/
@@ -2236,6 +2851,9 @@
 @ https://parahumans.wordpress.com/2012/12/08/monarch-16-5/
   - and It was powerful enough
   + and it was powerful enough
+
+  - fucked up mindset
+  + fucked-up mindset
 
 
 @ https://parahumans.wordpress.com/2012/12/11/monarch-16-6/
@@ -2389,6 +3007,9 @@
   - ninety percent or more of the the city
   + ninety percent or more of the city
 
+  - fucked up attempt at reassurance
+  + fucked-up attempt at reassurance
+
 
 @ https://parahumans.wordpress.com/2013/01/13/migration-17-6/
   - ground.  Not exactly
@@ -2488,6 +3109,11 @@
   + Skitter,” Grue said, “no
 
 
+@ https://parahumans.wordpress.com/2013/01/29/queen-18-4/
+  - fucked up city
+  + fucked-up city
+
+
 @ https://parahumans.wordpress.com/2013/02/02/queen-18-5/
   - —But she’s set
   + —but she’s set
@@ -2565,6 +3191,9 @@
   - Jessica observed  She looked like
   + Jessica observed.  She looked like
 
+  - is that good-looking
+  + is that good looking
+
 
 @ https://parahumans.wordpress.com/2013/02/09/queen-18-7/
   - apart,” he said. “We
@@ -2589,6 +3218,9 @@
 
   - better,” I said. “Eidolon
   + better,” I said, “Eidolon
+
+  - fucked up world
+  + fucked-up world
 
 
 @ https://parahumans.wordpress.com/2013/02/14/interlude-18-donation-bonus-4/
@@ -2637,7 +3269,7 @@
 
 @ https://parahumans.wordpress.com/2013/02/26/scourge-19-3/
   - No,” Regent said. “Blame
-  + No,” Regent said. “Blame
+  + No,” Regent said, “blame
 
   - Well,” Tattletale said. “Let’s
   + Well,” Tattletale said, “let’s
@@ -2652,6 +3284,9 @@
 
   - propellers   One caught her
   + propellers.  One caught her
+
+  - fucked up creations
+  + fucked-up creations
 
 
 @ https://parahumans.wordpress.com/2013/03/02/scourge-19-4/
@@ -3226,6 +3861,9 @@
   - <p><em>“Help’s on the way</em>.”</p>
   + <p>“<em>Help’s on the way.</em>”</p>
 
+  - fucked up coffin
+  + fucked-up coffin
+
 
 @ https://parahumans.wordpress.com/2013/07/25/interlude-26-donation-bonus-1/
   - think,” Dobrynja said. “You’ve
@@ -3308,6 +3946,9 @@
   - The Entity slowed
   + The entity slowed
 
+  - a fucked up stranger power
+  + a fucked-up stranger power
+
 
 @ https://parahumans.wordpress.com/2013/08/13/extinction-27-1/
   - East
@@ -3337,6 +3978,9 @@
 
   - “Maybe,” I said  “But
   + “Maybe,” I said.  “But
+
+  - fucked up world
+  + fucked-up world
 
 
 @ https://parahumans.wordpress.com/2013/08/24/extinction-27-5/
@@ -3435,6 +4079,9 @@
 
   - question,” I said. “Is
   + question,” I said, “is
+
+  - fucked up connection
+  + fucked-up connection
 
 
 @ https://parahumans.wordpress.com/2013/09/14/cockroaches-28-6/
@@ -3602,17 +4249,11 @@
   - Was that—Was it
   + Was that— Was it
 
-  - It would—would have
-  + It would— would have
-
   - Eastern seaboard
   + Eastern Seaboard
 
 
 @ https://parahumans.wordpress.com/2013/10/24/speck-30-5/
-  - clin—the clincher
-  + clin— the clincher
-
   - Have to—have to
   + Have to— Have to
 
@@ -3625,11 +4266,26 @@
   - I just—I needed
   + I just— I needed
 
+  - le—let
+  + le-let
+
+  - alo—alone
+  + alo-alone
+
+  - wan—wants
+  + wan-wants
+
+  - woul—wouldn’t work a—anyways.  N—no
+  + woul-wouldn’t work a-anyways.  N-no
+
+  - Sl—sl—
+  + Sl-sl—
+
   - Same strat—strat—same
-  + Same strat— strat— same
+  + Same strat-strat— Same
 
   - Wha—what?
-  + Wha— what?
+  + Wha-what?
 
   - You still—you still
   + You still— You stil
@@ -3637,38 +4293,17 @@
   - This—this is the
   + This— This is the
 
-  - all alo—alone
-  + all alo— alone
-
   - <em>S-s-sen—Sentiment</em>?
   + <em>S-s-sen— Sentiment?</em>
 
-  - le—let me
-  + le— let me
-
-  - wan—wants
-  + wan— wants
-
-  - woul—wouldn’t work a—anyways.  N—no use
-  + woul— wouldn’t work a— anyways.  N-no use
-
   - Need—need—need—need—
-  + Need— need— need— need—
+  + Need— Need— Need— Need—
 
   - Need—need—</em>
-  + Need— need—</em>
+  + Need— Need—</em>
 
   - Think—think
-  + Think— think
-
-  - It—it’s
-  + It— it’s
-
-  - not—not
-  + not— not
-
-  - Sl—sl—
-  + Sl-sl—
+  + Think— Think
 
   - I’d pretty much but there
   + I’d pretty much ???, but there
@@ -3684,29 +4319,23 @@
 
 
 @ https://parahumans.wordpress.com/2013/10/26/speck-30-6/
-  - frat—fratern—<em>clubs
-  + frat— fratern— <em>clubs
+  - frat—fratern—<em>clubs</em>
+  + frat-fratern—<em>clubs</em>
 
   - Glaistig U—the Faerie Queen
-  + Glaistig U— the Faerie Queen
-
-  - Strip—stripping flesh
-  + Strip— Stripping flesh
+  + Glaistig U— The Faerie Queen
 
   - Dis—Dissonance
-  + Dis— Dissonance
+  + Dis-dissonance
 
   - com-comf—why did it
-  + com— comf— why did it
+  + com-comf— Why did it
 
   - Needed—needed to
   + Needed— Needed to
 
   - into h—her pet
   + into h-her pet
-
-  - chan-chann—station to
-  + chan— chann— station to
 
   - Mm-m—my
   + Mm-m-my
@@ -3723,19 +4352,13 @@
 
 @ https://parahumans.wordpress.com/2013/10/29/30-7/
   - Con—conflict.
-  + Con— Conflict.
+  + Con-conflict.
 
   - That singing—Singing
   + That singing— Singing
 
-  - wasn’t the—wasn’t the
-  + wasn’t the— wasn’t the
-
   - I was—it was
   + I was— It was
-
-  - other two—I recognized
-  + other two— I recognized
 
   - W-wwha—ddo
   + W-wwha— ddo


### PR DESCRIPTION
* Use modern "v" regular expressions instead of "u" ones.
* Hyphenate various words ending in -shaped, -oriented, -sized, -eyed, -colored.
* Hyphenate double-check, mean-spirited, so-called, middle-aged, half-naked, full-fledged, top-notch, full-grown, old-fashioned, wide-reaching, lesser-known, better-known, X-foot-tall.
* When appropriate, hyphenate fucked-up, good-looking, top-notch.
* Fix golf-ball → golf ball, foot-ball → football, gasmask → gas mask, Traveller's → Travellers', change purse/change-purse → changepurse.
* Capitalize German shepherd, Rottweiler, Alzheimer's, YouTube, Caucasian.
* De-capitalize the market, the bay, my dad, track and field.
* More dialogue tag fixes throughout.
* Fixed spacing for the stuttering in the final chapters of Worm.
* Spot fixes to Worm through Arc 6.